### PR TITLE
http / ws で donation tracker に接続できるようにする

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -20,7 +20,8 @@
 			"properties": {
 				"domain": {"type": "string"},
 				"event": {"type": "number"},
-				"websocket": {"type": "string"}
+				"websocket": {"type": "string"},
+				"unsecure": {"type": "boolean"}
 			}
 		},
 		"twitch": {

--- a/configschema.json
+++ b/configschema.json
@@ -16,12 +16,12 @@
 		"tracker": {
 			"type": "object",
 			"additionalProperties": false,
-			"required": ["domain", "event", "websocket"],
+			"required": ["domain", "event", "websocket", "secure"],
 			"properties": {
 				"domain": {"type": "string"},
 				"event": {"type": "number"},
 				"websocket": {"type": "string"},
-				"unsecure": {"type": "boolean"}
+				"secure": {"type": "boolean", "default": true}
 			}
 		},
 		"twitch": {

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -26,7 +26,8 @@ export const tracker = (nodecg: NodeCG) => {
 	const runnersRep = nodecg.Replicant("runners");
 
 	const requestSearch = async <T>(type: string) => {
-		const url = new URL("/search", `https://${trackerConfig.domain}`);
+		const protocol = trackerConfig.unsecure ? "http" : "https";
+		const url = new URL("/search", `${protocol}://${trackerConfig.domain}`);
 		url.searchParams.append("type", type);
 		if (type !== "event") {
 			url.searchParams.append("event", String(trackerConfig.event));
@@ -172,9 +173,10 @@ export const tracker = (nodecg: NodeCG) => {
 	}, 10 * 1000);
 
 	const connectWebSocket = () => {
+		const protocol = trackerConfig.unsecure ? "ws" : "wss";
 		const url = new URL(
 			trackerConfig.websocket,
-			`wss://${trackerConfig.domain}`,
+			`${protocol}://${trackerConfig.domain}`,
 		);
 		log.warn("connecting websocket", url.href);
 		const ws = new WebSocket(url.href, {origin: url.href});

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -26,8 +26,8 @@ export const tracker = (nodecg: NodeCG) => {
 	const runnersRep = nodecg.Replicant("runners");
 
 	const requestSearch = async <T>(type: string) => {
-		const protocol = trackerConfig.unsecure ? "http" : "https";
-		const url = new URL("/search", `${protocol}://${trackerConfig.domain}`);
+		const schema = trackerConfig.secure ? "https" : "http";
+		const url = new URL("/search", `${schema}://${trackerConfig.domain}`);
 		url.searchParams.append("type", type);
 		if (type !== "event") {
 			url.searchParams.append("event", String(trackerConfig.event));
@@ -173,7 +173,7 @@ export const tracker = (nodecg: NodeCG) => {
 	}, 10 * 1000);
 
 	const connectWebSocket = () => {
-		const protocol = trackerConfig.unsecure ? "ws" : "wss";
+		const protocol = trackerConfig.secure ? "wss" : "ws";
 		const url = new URL(
 			trackerConfig.websocket,
 			`${protocol}://${trackerConfig.domain}`,

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -173,10 +173,10 @@ export const tracker = (nodecg: NodeCG) => {
 	}, 10 * 1000);
 
 	const connectWebSocket = () => {
-		const protocol = trackerConfig.secure ? "wss" : "ws";
+		const schema = trackerConfig.secure ? "wss" : "ws";
 		const url = new URL(
 			trackerConfig.websocket,
-			`${protocol}://${trackerConfig.domain}`,
+			`${schema}://${trackerConfig.domain}`,
 		);
 		log.warn("connecting websocket", url.href);
 		const ws = new WebSocket(url.href, {origin: url.href});

--- a/src/nodecg/generated/configschema.d.ts
+++ b/src/nodecg/generated/configschema.d.ts
@@ -14,6 +14,7 @@ export interface Configschema {
 		domain: string;
 		event: number;
 		websocket: string;
+		unsecure?: boolean;
 	};
 	twitch?: {
 		channelName: string;

--- a/src/nodecg/generated/configschema.d.ts
+++ b/src/nodecg/generated/configschema.d.ts
@@ -14,7 +14,7 @@ export interface Configschema {
 		domain: string;
 		event: number;
 		websocket: string;
-		unsecure?: boolean;
+		secure: boolean;
 	};
 	twitch?: {
 		channelName: string;


### PR DESCRIPTION
ローカル環境の donation tracker で開発するために、`http` `ws` で接続できるように設定を追加しました。