### PR TITLE
resolve #608 - 幕間動画を NodeCG 上で再生できるようにする

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -93,6 +93,7 @@
 				}
 			},
 			"required": ["staff", "partners", "volunteers"]
-		}
+		},
+		"preventVideoStop": {"type": "boolean"}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -193,6 +193,14 @@
 				"width": 6,
 				"headerColor": "#00BEBE",
 				"workspace": "3-donations"
+			},
+			{
+				"name": "video-control",
+				"title": "幕間動画操作",
+				"file": "video-control.html",
+				"width": 3,
+				"headerColor": "#00BEBE",
+				"workspace": "2-misc"
 			}
 		],
 		"graphics": [
@@ -226,6 +234,12 @@
 				"file": "credit.html",
 				"width": 1920,
 				"height": 1030
+			},
+			{
+				"file": "interval-video.html",
+				"width": 1920,
+				"height": 1080,
+				"singleInstance": true
 			}
 		],
 		"assetCategories": [
@@ -261,6 +275,14 @@
 			{
 				"name": "setup-background-video",
 				"title": "セットアップ背景動画",
+				"allowedTypes": [
+					"mp4",
+					"webm"
+				]
+			},
+			{
+				"name": "interval-video",
+				"title": "幕間動画",
 				"allowedTypes": [
 					"mp4",
 					"webm"

--- a/schemas/video-control.json
+++ b/schemas/video-control.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema",
+
+	"oneOf": [
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"status": {"type": "string", "enum": ["play", "pause"]},
+				"current": {"type": "number"},
+				"duration": {"type": "number"},
+				"path": {"type": "string"}
+			},
+			"required": ["status", "current", "duration", "path"]
+		},
+		{"type": "null"}
+	]
+}

--- a/src/browser/dashboard/components/lib/colored-button.tsx
+++ b/src/browser/dashboard/components/lib/colored-button.tsx
@@ -17,7 +17,7 @@ export const ColoredButton: React.ComponentType<Props> = (props) => (
 	>
 		<Button
 			{...props.ButtonProps}
-			style={{whiteSpace: "nowrap"}}
+			style={{...props.ButtonProps?.style, whiteSpace: "nowrap"}}
 			color='primary'
 		>
 			{props.children}

--- a/src/browser/dashboard/views/video-control.tsx
+++ b/src/browser/dashboard/views/video-control.tsx
@@ -43,18 +43,13 @@ const Control = ({control}: {control: VideoControl}) => {
 						value={(control.current / control.duration) * 100}
 					/>
 					<ColoredButton
-						color={lightBlue}
-						ButtonProps={{
-							onClick: () => {
-								nodecg.sendMessage("video:reset");
-							},
-						}}
-					>
-						<SkipPreviousIcon />
-					</ColoredButton>
-					<ColoredButton
 						color={green}
 						ButtonProps={{
+							style: {
+								gridColumn: nodecg.bundleConfig.preventVideoStop
+									? "1 / 5"
+									: "2 / 3",
+							},
 							disabled: control.status === "play",
 							onClick: () => {
 								nodecg.sendMessage("video:play");
@@ -63,28 +58,54 @@ const Control = ({control}: {control: VideoControl}) => {
 					>
 						<PlayArrowIcon />
 					</ColoredButton>
-					<ColoredButton
-						color={orange}
-						ButtonProps={{
-							disabled: control.status === "pause",
-							onClick: () => {
-								nodecg.sendMessage("video:pause");
-							},
-						}}
-					>
-						<PauseIcon />
-					</ColoredButton>
-					<ColoredButton
-						color={pink}
-						ButtonProps={{
-							disabled: control.status === "pause",
-							onClick: () => {
-								nodecg.sendMessage("video:stop");
-							},
-						}}
-					>
-						<StopIcon />
-					</ColoredButton>
+					{!nodecg.bundleConfig.preventVideoStop && (
+						<>
+							<ColoredButton
+								color={lightBlue}
+								ButtonProps={{
+									style: {
+										gridColumn: "1 / 2",
+										gridRow: 3,
+									},
+									onClick: () => {
+										nodecg.sendMessage("video:reset");
+									},
+								}}
+							>
+								<SkipPreviousIcon />
+							</ColoredButton>
+							<ColoredButton
+								color={orange}
+								ButtonProps={{
+									style: {
+										gridColumn: "3 / 4",
+										gridRow: 3,
+									},
+									disabled: control.status === "pause",
+									onClick: () => {
+										nodecg.sendMessage("video:pause");
+									},
+								}}
+							>
+								<PauseIcon />
+							</ColoredButton>
+							<ColoredButton
+								color={pink}
+								ButtonProps={{
+									style: {
+										gridColumn: "4 / 5",
+										gridRow: 3,
+									},
+									disabled: control.status === "pause",
+									onClick: () => {
+										nodecg.sendMessage("video:stop");
+									},
+								}}
+							>
+								<StopIcon />
+							</ColoredButton>
+						</>
+					)}
 				</>
 			)}
 		</div>

--- a/src/browser/dashboard/views/video-control.tsx
+++ b/src/browser/dashboard/views/video-control.tsx
@@ -134,6 +134,7 @@ const App = () => {
 				}}
 			>
 				<label>動画選択</label>
+
 				<select
 					onChange={(e) => {
 						nodecg.sendMessage(

--- a/src/browser/dashboard/views/video-control.tsx
+++ b/src/browser/dashboard/views/video-control.tsx
@@ -147,7 +147,7 @@ const App = () => {
 					style={{
 						width: "100%",
 					}}
-					defaultValue={control?.path || SELECT_DEFAULT}
+					value={control?.path || SELECT_DEFAULT}
 				>
 					<option value={SELECT_DEFAULT}>-</option>
 					{[...(videos || [])]

--- a/src/browser/dashboard/views/video-control.tsx
+++ b/src/browser/dashboard/views/video-control.tsx
@@ -1,0 +1,150 @@
+import {createTheme, LinearProgress, MuiThemeProvider} from "@material-ui/core";
+import "modern-normalize";
+import ReactDOM from "react-dom";
+import {useReplicant} from "../../use-replicant";
+import PlayArrowIcon from "@material-ui/icons/PlayArrow";
+import SkipPreviousIcon from "@material-ui/icons/SkipPrevious";
+import PauseIcon from "@material-ui/icons/Pause";
+import StopIcon from "@material-ui/icons/Stop";
+import {ColoredButton} from "../components/lib/colored-button";
+import {green, lightBlue, orange, pink} from "@material-ui/core/colors";
+import {VideoControl} from "../../../nodecg/generated";
+
+const parseDuration = (seconds: number) => {
+	return `${String(Math.floor(seconds / 60)).padStart(2, "0")}:${String(
+		Math.floor(seconds % 60),
+	).padStart(2, "0")}`;
+};
+
+const Control = ({control}: {control: VideoControl}) => {
+	return (
+		<div
+			style={{
+				display: "grid",
+				gridTemplateColumns: "1fr 1fr 1fr 1fr",
+				gap: "8px",
+			}}
+		>
+			{control && (
+				<>
+					<div
+						style={{
+							gridColumn: "1 / 5",
+							textAlign: "center",
+						}}
+					>
+						{parseDuration(control.current)} / {parseDuration(control.duration)}
+					</div>
+					<LinearProgress
+						style={{
+							gridColumn: "1 / 5",
+						}}
+						variant='determinate'
+						value={(control.current / control.duration) * 100}
+					/>
+					<ColoredButton
+						color={lightBlue}
+						ButtonProps={{
+							onClick: () => {
+								nodecg.sendMessage("video:reset");
+							},
+						}}
+					>
+						<SkipPreviousIcon />
+					</ColoredButton>
+					<ColoredButton
+						color={green}
+						ButtonProps={{
+							disabled: control.status === "play",
+							onClick: () => {
+								nodecg.sendMessage("video:play");
+							},
+						}}
+					>
+						<PlayArrowIcon />
+					</ColoredButton>
+					<ColoredButton
+						color={orange}
+						ButtonProps={{
+							disabled: control.status === "pause",
+							onClick: () => {
+								nodecg.sendMessage("video:pause");
+							},
+						}}
+					>
+						<PauseIcon />
+					</ColoredButton>
+					<ColoredButton
+						color={pink}
+						ButtonProps={{
+							disabled: control.status === "pause",
+							onClick: () => {
+								nodecg.sendMessage("video:stop");
+							},
+						}}
+					>
+						<StopIcon />
+					</ColoredButton>
+				</>
+			)}
+		</div>
+	);
+};
+
+const SELECT_DEFAULT = "none";
+
+const App = () => {
+	const control = useReplicant("video-control");
+	const videos = useReplicant("assets:interval-video");
+
+	return (
+		<MuiThemeProvider
+			theme={createTheme({
+				props: {
+					MuiButton: {
+						variant: "contained",
+					},
+				},
+			})}
+		>
+			<div
+				style={{
+					padding: "8px",
+				}}
+			>
+				<label>動画選択</label>
+				<select
+					onChange={(e) => {
+						nodecg.sendMessage(
+							"video:init",
+							e.currentTarget.value !== SELECT_DEFAULT
+								? e.currentTarget.value
+								: null,
+						);
+					}}
+					disabled={control?.status === "play"}
+					style={{
+						width: "100%",
+					}}
+					defaultValue={control?.path || SELECT_DEFAULT}
+				>
+					<option value={SELECT_DEFAULT}>-</option>
+					{[...(videos || [])].sort().map((v, idx) => (
+						<option key={idx} value={v.url}>
+							{v.name}
+						</option>
+					))}
+				</select>
+				<div
+					style={{
+						margin: "8px",
+					}}
+				>
+					<Control control={control} />
+				</div>
+			</div>
+		</MuiThemeProvider>
+	);
+};
+
+ReactDOM.render(<App></App>, document.getElementById("root"));

--- a/src/browser/dashboard/views/video-control.tsx
+++ b/src/browser/dashboard/views/video-control.tsx
@@ -150,11 +150,13 @@ const App = () => {
 					defaultValue={control?.path || SELECT_DEFAULT}
 				>
 					<option value={SELECT_DEFAULT}>-</option>
-					{[...(videos || [])].sort().map((v, idx) => (
-						<option key={idx} value={v.url}>
-							{v.name}
-						</option>
-					))}
+					{[...(videos || [])]
+						.sort((a, b) => a.name.localeCompare(b.name))
+						.map((v, idx) => (
+							<option key={idx} value={v.url}>
+								{v.name}
+							</option>
+						))}
 				</select>
 				<div
 					style={{

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -49,6 +49,11 @@ const App = () => {
 		if (!video) {
 			return;
 		}
+
+		nodecg.listenFor("video:init", (path) => {
+			initialize(path);
+		});
+
 		nodecg.listenFor("video:play", () => {
 			video.play();
 		});

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -82,20 +82,18 @@ const App = () => {
 	}, []);
 
 	return (
-		<>
-			<video
-				ref={videoRef}
-				src={videoControl?.path}
-				style={{
-					minWidth: "100vw",
-					minHeight: "100vh",
-				}}
-				onTimeUpdate={onTimeUpdate}
-				onPlay={onPlay}
-				onPause={onPause}
-				onEnded={onEnded}
-			/>
-		</>
+		<video
+			ref={videoRef}
+			src={videoControl?.path}
+			style={{
+				minWidth: "100vw",
+				minHeight: "100vh",
+			}}
+			onTimeUpdate={onTimeUpdate}
+			onPlay={onPlay}
+			onPause={onPause}
+			onEnded={onEnded}
+		/>
 	);
 };
 

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -1,5 +1,5 @@
 import "modern-normalize";
-import {createRef, useEffect} from "react";
+import {useEffect} from "react";
 import ReactDOM from "react-dom";
 import {useReplicant} from "../../use-replicant";
 
@@ -7,7 +7,6 @@ const videoControlRep = nodecg.Replicant("video-control");
 
 const App = () => {
 	const videoControl = useReplicant("video-control");
-	const videoRef = createRef<HTMLVideoElement>();
 
 	const initialize = (path: string | null) => {
 		videoControlRep.value = path
@@ -20,79 +19,79 @@ const App = () => {
 			: null;
 	};
 
-	nodecg.listenFor("video:init", (path) => {
-		initialize(path);
-	});
-
-	nodecg.listenFor("video:play", () => {
-		videoRef.current?.play();
-	});
-
-	nodecg.listenFor("video:pause", () => {
-		videoRef.current?.pause();
-	});
-
-	nodecg.listenFor("video:reset", () => {
-		if (videoRef.current) {
-			videoRef.current.currentTime = 0;
-		}
-	});
-
-	nodecg.listenFor("video:stop", () => {
-		if (videoRef.current) {
-			videoRef.current.pause();
-			videoRef.current.currentTime = 0;
-		}
-	});
-
 	const onPlay = () => {
-		if (videoRef.current && videoControlRep.value) {
+		if (videoControlRep.value) {
 			videoControlRep.value.status = "play";
 		}
 	};
 
 	const onPause = () => {
-		if (videoRef.current && videoControlRep.value) {
+		if (videoControlRep.value) {
 			videoControlRep.value.status = "pause";
 		}
 	};
 
-	const onTimeUpdate = () => {
-		if (
-			videoRef.current &&
-			videoControlRep.value &&
-			!isNaN(videoRef.current.duration)
-		) {
-			videoControlRep.value.current = videoRef.current.currentTime;
-			videoControlRep.value.duration = videoRef.current.duration;
+	const onTimeUpdate = (video: HTMLVideoElement) => {
+		if (videoControlRep.value && !isNaN(video.duration)) {
+			videoControlRep.value.current = video.currentTime;
+			videoControlRep.value.duration = video.duration;
 		}
 	};
 
-	const onEnded = () => {
-		if (videoRef.current && videoControlRep.value) {
+	const onEnded = (video: HTMLVideoElement) => {
+		if (videoControlRep.value) {
 			videoControlRep.value.status = "pause";
-			videoControlRep.value.current = videoRef.current.duration;
+			videoControlRep.value.current = video.duration;
 		}
+	};
+
+	const onVideoRendered = (video: HTMLVideoElement | null) => {
+		if (!video) {
+			return;
+		}
+		nodecg.listenFor("video:play", () => {
+			video.play();
+		});
+
+		nodecg.listenFor("video:pause", () => {
+			video.pause();
+		});
+
+		nodecg.listenFor("video:reset", () => {
+			video.currentTime = 0;
+		});
+
+		nodecg.listenFor("video:stop", () => {
+			video.pause();
+			video.currentTime = 0;
+		});
+
+		video.onplay = onPlay;
+		video.onpause = onPause;
+		video.ontimeupdate = () => onTimeUpdate(video);
+		video.onended = () => onEnded(video);
+
+		nodecg.readReplicant("video-control", (v) => {
+			if (v) {
+				video.currentTime = v.current;
+			}
+		});
 	};
 
 	useEffect(() => {
-		nodecg.readReplicant("video-control", (v) => {
-			initialize(v?.path || null);
+		nodecg.listenFor("video:init", (path) => {
+			initialize(path);
 		});
 	}, []);
 
 	return (
 		<video
-			ref={videoRef}
+			ref={onVideoRendered}
 			src={videoControl?.path}
 			style={{
 				minWidth: "100vw",
 				minHeight: "100vh",
 			}}
-			onTimeUpdate={onTimeUpdate}
-			onPlay={onPlay}
-			onPause={onPause}
-			onEnded={onEnded}
 		/>
 	);
 };

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -70,17 +70,11 @@ const App = () => {
 		video.onpause = onPause;
 		video.ontimeupdate = () => onTimeUpdate(video);
 		video.onended = () => onEnded(video);
-
-		nodecg.readReplicant("video-control", (v) => {
-			if (v) {
-				video.currentTime = v.current;
-			}
-		});
 	};
 
 	useEffect(() => {
-		nodecg.listenFor("video:init", (path) => {
-			initialize(path);
+		nodecg.readReplicant("video-control", (v) => {
+			initialize(v?.path || null);
 		});
 	}, []);
 

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -1,0 +1,102 @@
+import "modern-normalize";
+import {createRef, useEffect} from "react";
+import ReactDOM from "react-dom";
+import {useReplicant} from "../../use-replicant";
+
+const videoControlRep = nodecg.Replicant("video-control");
+
+const App = () => {
+	const videoControl = useReplicant("video-control");
+	const videoRef = createRef<HTMLVideoElement>();
+
+	const initialize = (path: string | null) => {
+		videoControlRep.value = path
+			? {
+					path,
+					current: 0,
+					duration: 0,
+					status: "pause",
+			  }
+			: null;
+	};
+
+	nodecg.listenFor("video:init", (path) => {
+		initialize(path);
+	});
+
+	nodecg.listenFor("video:play", () => {
+		videoRef.current?.play();
+	});
+
+	nodecg.listenFor("video:pause", () => {
+		videoRef.current?.pause();
+	});
+
+	nodecg.listenFor("video:reset", () => {
+		if (videoRef.current) {
+			videoRef.current.currentTime = 0;
+		}
+	});
+
+	nodecg.listenFor("video:stop", () => {
+		if (videoRef.current) {
+			videoRef.current.pause();
+			videoRef.current.currentTime = 0;
+		}
+	});
+
+	const onPlay = () => {
+		if (videoRef.current && videoControlRep.value) {
+			videoControlRep.value.status = "play";
+		}
+	};
+
+	const onPause = () => {
+		if (videoRef.current && videoControlRep.value) {
+			videoControlRep.value.status = "pause";
+		}
+	};
+
+	const onTimeUpdate = () => {
+		if (
+			videoRef.current &&
+			videoControlRep.value &&
+			!isNaN(videoRef.current.duration)
+		) {
+			videoControlRep.value.current = videoRef.current.currentTime;
+			videoControlRep.value.duration = videoRef.current.duration;
+		}
+	};
+
+	const onEnded = () => {
+		if (videoRef.current && videoControlRep.value) {
+			videoControlRep.value.status = "pause";
+			videoControlRep.value.current = videoRef.current.duration;
+		}
+	};
+
+	useEffect(() => {
+		nodecg.readReplicant("video-control", (v) => {
+			initialize(v?.path || null);
+		});
+	}, []);
+
+	return (
+		<>
+			<video
+				ref={videoRef}
+				src={videoControl?.path}
+				style={{
+					minWidth: "100vw",
+					minHeight: "100vh",
+				}}
+				onTimeUpdate={onTimeUpdate}
+				onPlay={onPlay}
+				onPause={onPause}
+				onEnded={onEnded}
+			/>
+		</>
+	);
+};
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/src/nodecg/messages.ts
+++ b/src/nodecg/messages.ts
@@ -40,4 +40,9 @@ export type MessageMap = {
 	toggleCameraName: {};
 	startEndCredit: {};
 	clearDonationQueue: {};
+	"video:init": {data: string | null};
+	"video:play": {};
+	"video:pause": {};
+	"video:reset": {};
+	"video:stop": {};
 };

--- a/src/nodecg/replicants.ts
+++ b/src/nodecg/replicants.ts
@@ -21,6 +21,7 @@ import type {AccessToken} from "@twurple/auth";
 import {Runners} from "./generated/runners";
 import {Donations} from "./generated/donations";
 import {DonationQueue} from "./generated/donation-queue";
+import {VideoControl} from "./generated/video-control";
 
 type Run = NonNullable<CurrentRun>;
 type Participant = Run["runners"][number];
@@ -67,6 +68,8 @@ type ReplicantMap = {
 	donations: Donations;
 	"donation-queue": DonationQueue;
 	"bid-challenge": BidChallenge;
+	"video-control": VideoControl;
+	"assets:interval-video": Assets[];
 };
 
 export {


### PR DESCRIPTION
assets に再生したい動画を追加します

![image](https://user-images.githubusercontent.com/33190610/208897978-6ed61553-a6a2-480d-8343-ad4eee8eb337.png)

## dashboard

動画を選択して再生します。 **interval-video の graphics を開いていないと動かないです**

bundleConfig `preventVideoStop` = `true` にすることで再生以外のコントロールを非表示にします（途中で映像止める放送事故を防ぐため）

![image](https://user-images.githubusercontent.com/33190610/208898377-54bfed90-1e0b-4131-bc32-26aef7fea102.png)

![image](https://user-images.githubusercontent.com/33190610/208898914-c1f3cb75-53ee-4576-a6c8-d9d5ec0153e6.png)

各コントロールは左から、

- 巻き戻し：再生位置を最初に戻す
- 再生：停止中の動画を再生する
- 一時停止：再生位置を動かさずに停止する
- 停止：再生位置を最初に戻して停止する

## graphics

`interval-video.html`

`nodecg.sendMessage` で諸々の入力を受けて動画の操作+ Replicant の更新をします

Replicant を操作する都合上 `singleInstance` にしてます

更新すると再生位置が最初に戻ります（ `preventVideoStop` = `true` の時に再生を止める裏技的な運用もできます）

![image](https://user-images.githubusercontent.com/33190610/208900090-b2ef401b-1a5a-42a6-8d5a-a61e7adc2be8.png)
