### PR TITLE
走者複数で各タイマーを完走にしたのにマスタータイマーが止まらないことがある問題の修正

### DIFF
--- a/schemas/timer.json
+++ b/schemas/timer.json
@@ -4,18 +4,30 @@
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
-		"raw": {"type": "number", "default": 0},
+		"raw": {"type": "number", "default": 0, "description": "タイマー経過秒"},
 		"hours": {"type": "number", "default": 0},
 		"minutes": {"type": "number", "default": 0},
 		"seconds": {"type": "number", "default": 0},
-		"formatted": {"type": "string", "default": "0:00:00"},
-		"timestamp": {"type": "number", "default": 0},
+		"formatted": {
+			"type": "string",
+			"default": "0:00:00",
+			"description": "h:mm:ss形式の経過時間"
+		},
+		"timestamp": {
+			"type": "number",
+			"default": 0,
+			"description": "タイマーレプリカントの生成時刻。これを元にタイマーの再計算を行う。"
+		},
 		"timerState": {
 			"enum": ["Finished", "Running", "Stopped"],
 			"type": "string",
-			"default": "Stopped"
+			"default": "Stopped",
+			"description": "Finished: 全走者が完走orリタイアになった状態"
 		},
-		"forfeit": {"type": "boolean", "default": false},
+		"forfeit": {
+			"type": "boolean",
+			"default": false
+		},
 
 		"results": {
 			"type": "array",
@@ -30,14 +42,23 @@
 							"hours": {"type": "number", "default": 0},
 							"minutes": {"type": "number", "default": 0},
 							"seconds": {"type": "number", "default": 0},
-							"formatted": {"type": "string", "default": ""},
+							"formatted": {
+								"type": "string",
+								"default": "",
+								"description": "h:mm:ss形式の経過時間。走者ごとのタイムは、完走orリタイアの時のみセットされる"
+							},
 							"timestamp": {"type": "number", "default": 0},
 							"timerState": {
 								"enum": ["Finished", "Running", "Stopped"],
 								"type": "string",
-								"default": "Stopped"
+								"default": "Stopped",
+								"description": "Finished: 完走, Stopped: 開始前、リタイア"
 							},
-							"forfeit": {"type": "boolean", "default": false},
+							"forfeit": {
+								"type": "boolean",
+								"default": false,
+								"description": "リタイアフラグ"
+							},
 							"place": {"type": "number", "multipleOf": 1},
 							"results": {"type": "array"}
 						},

--- a/src/extension/timekeeping.ts
+++ b/src/extension/timekeeping.ts
@@ -123,8 +123,14 @@ export const timekeeping = (nodecg: NodeCG) => {
 		if (currentRunRep.value.runners === undefined) {
 			return;
 		}
-		const allRunnersFinished = currentRunRep.value.runners.every((_, index) =>
-			Boolean(timerRep.value && timerRep.value.results[index]),
+
+		// 全ての走者のresultが入ってるかをチェックし、入ってたらマスタータイマーを止める
+		// 名前が入ってない走者は無視する
+		const allRunnersFinished = currentRunRep.value.runners.every(
+			(runner, index) =>
+				Boolean(
+					!runner.name || (timerRep.value && timerRep.value.results[index]),
+				),
 		);
 		if (allRunnersFinished) {
 			stop();

--- a/src/nodecg/generated/timer.d.ts
+++ b/src/nodecg/generated/timer.d.ts
@@ -6,12 +6,24 @@
  */
 
 export interface Timer {
+	/**
+	 * タイマー経過秒
+	 */
 	raw: number;
 	hours: number;
 	minutes: number;
 	seconds: number;
+	/**
+	 * h:mm:ss形式の経過時間
+	 */
 	formatted: string;
+	/**
+	 * タイマーレプリカントの生成時刻。これを元にタイマーの再計算を行う。
+	 */
 	timestamp: number;
+	/**
+	 * Finished: 全走者が完走orリタイアになった状態
+	 */
 	timerState: 'Finished' | 'Running' | 'Stopped';
 	forfeit: boolean;
 	results: (null | {
@@ -19,9 +31,18 @@ export interface Timer {
 		hours: number;
 		minutes: number;
 		seconds: number;
+		/**
+		 * h:mm:ss形式の経過時間。走者ごとのタイムは、完走orリタイアの時のみセットされる
+		 */
 		formatted: string;
 		timestamp: number;
+		/**
+		 * Finished: 完走, Stopped: 開始前、リタイア
+		 */
 		timerState: 'Finished' | 'Running' | 'Stopped';
+		/**
+		 * リタイアフラグ
+		 */
 		forfeit: boolean;
 		place?: number;
 		results?: unknown[];


### PR DESCRIPTION
- issue #509
- タイマー稼働後に走者を消すと、currentRunRep.value.runnersには残りっぱなしになって、全走者が走り終えた判定にならないことがわかった。名前が入ってない走者のレプリカントは無視することでこれを解決。
- ついでにtimerのschemaにコメントを書いた
- 動作イメージ

![timer](https://user-images.githubusercontent.com/3125070/208787818-687208c7-01ae-4074-a52b-f9d422233e54.gif)
