### PR TITLE
resolve #600 - エンドロール画面のフォント修正

### DIFF
--- a/src/browser/graphics/components/lib/fit-text.tsx
+++ b/src/browser/graphics/components/lib/fit-text.tsx
@@ -5,12 +5,13 @@ import {
 	useRef,
 	useState,
 } from "react";
-import {BoldText, ThinText} from "./text";
+import {BoldText, ThinText, CreditText} from "./text";
 
 export const FitText: FunctionComponent<{
 	defaultSize: number;
 	children: string | undefined | null;
 	thin?: boolean;
+	credit?: boolean;
 	style?: CSSProperties;
 }> = (props) => {
 	const [size, setSize] = useState(props.defaultSize);
@@ -44,11 +45,9 @@ export const FitText: FunctionComponent<{
 				...props.style,
 			}}
 		>
-			{props.thin ? (
-				<ThinText>{props.children}</ThinText>
-			) : (
-				<BoldText>{props.children}</BoldText>
-			)}
+			{!props.credit && props.thin && <ThinText>{props.children}</ThinText>}
+			{!props.credit && !props.thin && <BoldText>{props.children}</BoldText>}
+			{props.credit && <CreditText>{props.children}</CreditText>}
 		</div>
 	);
 };

--- a/src/browser/graphics/components/lib/text.ts
+++ b/src/browser/graphics/components/lib/text.ts
@@ -19,13 +19,13 @@ export const TimerText = styled.div`
 	white-space: nowrap;
 `;
 export const CreditText = styled.div`
-	font-family: minion-3, sans-serif;
+	font-family: fot-chiaro-std, sans-serif;
 	font-weight: 500; /* medium */
 	font-style: normal;
 	white-space: nowrap;
 `;
 export const CreditTitleText = styled.div`
-	font-family: fot-chiaro-std, sans-serif;
+	font-family: minion-3, sans-serif;
 	font-weight: 700; /* bold */
 	font-style: normal;
 	white-space: nowrap;

--- a/src/browser/graphics/components/lib/text.ts
+++ b/src/browser/graphics/components/lib/text.ts
@@ -18,3 +18,15 @@ export const TimerText = styled.div`
 	font-style: normal;
 	white-space: nowrap;
 `;
+export const CreditText = styled.div`
+	font-family: minion-3, sans-serif;
+	font-weight: 500; /* medium */
+	font-style: normal;
+	white-space: nowrap;
+`;
+export const CreditTitleText = styled.div`
+	font-family: fot-chiaro-std, sans-serif;
+	font-weight: 700; /* bold */
+	font-style: normal;
+	white-space: nowrap;
+`;

--- a/src/browser/graphics/views/credit.tsx
+++ b/src/browser/graphics/views/credit.tsx
@@ -1,7 +1,7 @@
 import {FC, useEffect, useRef, useState} from "react";
 import ReactDOM from "react-dom";
 import {FitText} from "../components/lib/fit-text";
-import {BoldText, ThinText} from "../components/lib/text";
+import {BoldText, CreditTitleText} from "../components/lib/text";
 import topLogo from "../images/header_rij.svg";
 import gsap from "gsap";
 import chunk from "lodash-es/chunk";
@@ -115,7 +115,7 @@ const App: FC = () => {
 					backgroundColor: "rgba(37, 48, 58, 0.6)",
 				}}
 			>
-				<ThinText
+				<CreditTitleText
 					ref={titleRef}
 					style={{
 						position: "absolute",
@@ -130,7 +130,7 @@ const App: FC = () => {
 					}}
 				>
 					{title}
-				</ThinText>
+				</CreditTitleText>
 				<div
 					ref={namesRef}
 					style={{
@@ -147,7 +147,7 @@ const App: FC = () => {
 					}}
 				>
 					{names.map((name) => (
-						<FitText defaultSize={40} thin>
+						<FitText defaultSize={40} credit>
 							{name}
 						</FitText>
 					))}


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/600

# 概要
- credit用のStyled Componentを追加
- FitTextに、credit用のフラグを追加

# その他気になること
- Adobe Fontsが使えないので実際の動作は未確認です。
  - 他のフォントを指定した時に、エンドロールのフォントが反映することの確認は済み
- JSXもこのレイアウト弄るのも初めてなので変なところあったらご指摘お願いします。