### PR TITLE
セットアップ画面　すぐできそうな修正のみ

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -4,6 +4,7 @@
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
+		"isOnsite": {"type": "boolean"},
 		"obs": {
 			"type": "object",
 			"properties": {

--- a/src/browser/graphics/views/break.tsx
+++ b/src/browser/graphics/views/break.tsx
@@ -51,7 +51,7 @@ const Upcoming = () => {
 			style={{
 				position: "absolute",
 				left: "100px",
-				top: "250px",
+				top: nodecg.bundleConfig.isOnsite ? "220px" : "250px",
 				display: "grid",
 				gridTemplateRows: "30px 10px 100px repeat(auto-fill, 60px 30px)",
 				alignContent: "start",
@@ -174,25 +174,25 @@ const Sponsor = () => {
 	);
 };
 
-const GradientOverlay = () => {
-	return (
-		<div
-			style={{
-				position: "absolute",
-				width: "1920px",
-				height: "1030px",
-				overflow: "hidden",
-				background: `
-					linear-gradient(
-						to right,
-						rgba(37, 48, 58, 0.5),
-						rgba(37, 48, 58, 0.4) 75%,
-						rgba(37, 48, 58, 0) 100%
-					)`,
-			}}
-		></div>
-	);
-};
+// const GradientOverlay = () => {
+// 	return (
+// 		<div
+// 			style={{
+// 				position: "absolute",
+// 				width: "1920px",
+// 				height: "1030px",
+// 				overflow: "hidden",
+// 				background: `
+// 					linear-gradient(
+// 						to right,
+// 						rgba(37, 48, 58, 0.5),
+// 						rgba(37, 48, 58, 0.4) 75%,
+// 						rgba(37, 48, 58, 0) 100%
+// 					)`,
+// 			}}
+// 		></div>
+// 	);
+// };
 
 const TweetContainer = () => {
 	const tweetTag = useRef(null);
@@ -283,7 +283,7 @@ const App = () => {
 				color: "white",
 			}}
 		>
-			<GradientOverlay></GradientOverlay>
+			{/* <GradientOverlay></GradientOverlay> */}
 			<EventLogo
 				style={{position: "absolute", left: "30px", top: "20px"}}
 			></EventLogo>


### PR DESCRIPTION
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/597

セットアップ画面の要望のうち以下に対応しました

- オフライン・オンライン開催で「次のゲーム」の表示位置が違う
  - `isOnsite` コンフィグに設定すれば変わるようにしました
- w2022 は背景動画に影をつけるのでレイアウト側の影が不要
  - 該当箇所コメントアウトしただけです