### PR TITLE
resolve #598 - ゲーム中画面レイアウトの修正

### DIFF
--- a/src/browser/graphics/components/nameplate/index.tsx
+++ b/src/browser/graphics/components/nameplate/index.tsx
@@ -45,18 +45,24 @@ const useSocial = (icon: string, text?: string) => {
 const NamePlateContent = ({
 	runner,
 	style,
+	isRaceRunner,
 }: {
 	runner?: Participant;
 	style?: CSSProperties;
+	isRaceRunner?: boolean;
 }) => {
 	const nameRef = useRef<HTMLDivElement>(null);
+	const emptyRef = useRef<HTMLDivElement>(null);
 	const [twitter, twitterRef] = useSocial(iconTwitter, runner?.twitter);
 	const [twitch, twitchRef] = useSocial(iconTwitch, runner?.twitch);
 	const [nico, nicoRef] = useSocial(iconNico, runner?.nico);
 
 	useEffect(() => {
 		const refs = filterNonNullable(
-			[nameRef, twitterRef, twitchRef, nicoRef].map((ref) => ref?.current ?? nameRef.current),
+			!isRaceRunner ? 
+				[nameRef, twitterRef, twitchRef, nicoRef].map((ref) => ref?.current ?? nameRef.current)
+				:
+				[emptyRef, twitterRef, twitchRef, nicoRef].map((ref) => ref?.current ?? emptyRef.current)
 		);
 		if (!refs[0]) {
 			return;
@@ -72,7 +78,7 @@ const NamePlateContent = ({
 		};
 	}, [nicoRef, twitterRef, twitchRef]);
 
-	return (
+	return !isRaceRunner ? (
 		<div
 			style={{
 				display: "grid",
@@ -83,13 +89,41 @@ const NamePlateContent = ({
 		>
 			<ThinText
 				ref={nameRef}
-				style={{fontSize: "26px", opacity: 0, ...textPlacement}}
+				style={{ fontSize: "26px", opacity: 0, ...textPlacement}}
 			>
 				{runner?.name}
 			</ThinText>
 			{twitter}
 			{twitch}
 			{nico}
+		</div>
+	) : (
+		<div
+			style={{
+				display: "grid",
+				placeSelf: "center start",
+				...style,
+			}}
+		>
+			<ThinText
+				style={{fontSize: "26px", marginLeft: "10px", ...textPlacement}}
+			>
+				{runner?.name}
+				</ThinText>
+				<div
+					style={{
+						display: "grid",
+						placeContent: "center",
+						placeItems: "center",
+						marginLeft: "20px",
+						...style,
+					}}
+				>
+					<div ref={emptyRef}></div>
+					{twitter}
+					{twitch}
+					{nico}
+				</div>
 		</div>
 	);
 };
@@ -123,7 +157,8 @@ export const NamePlate = ({
 		typeof index === "number" ? (
 			<NamePlateContent
 				runner={currentRun[kind][index]}
-				style={{gridRow: "1 / 2", gridColumn: "3 / 4"}}
+				style={{ gridRow: "1 / 2", gridColumn: "3 / 4" }}
+				isRaceRunner={race && kind === "runners"}
 			></NamePlateContent>
 		) : (
 			<div

--- a/src/browser/graphics/components/nameplate/index.tsx
+++ b/src/browser/graphics/components/nameplate/index.tsx
@@ -56,15 +56,12 @@ const NamePlateContent = ({
 
 	useEffect(() => {
 		const refs = filterNonNullable(
-			[nameRef, twitterRef, twitchRef, nicoRef].map((ref) => ref?.current),
+			[nameRef, twitterRef, twitchRef, nicoRef].map((ref) => ref?.current ?? nameRef.current),
 		);
 		if (!refs[0]) {
 			return;
 		}
-		if (refs.length === 1) {
-			gsap.set(refs[0], {opacity: 1});
-			return;
-		}
+
 		const tl = gsap.timeline({repeat: -1});
 		for (const ref of refs) {
 			tl.fromTo(ref, {opacity: 0}, {opacity: 1, duration: 0.5});


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/598

# 概要
- NameplateContext内各種Refに該当のSNSが存在しない場合に名前を代入するよう修正
- レースの場合、名前は常時表示し横にSNSを表示するよう修正

# その他気になること
- 名前→名前と切り替わる際もクロスフェードするのが若干気になるが対応考えるとつらいので妥協してます
- ~~レース時に名前を常時表示する対応は後々~~ 対応済
- 要件にはマイク音に合わせてアイコンを点滅する機能もあるが、X32からAPIを生やす必要があるため保留
- DSのレース画面に対応していないが、今回のイベントにDSのレースは無いので保留