### PR TITLE
Twitchタイトルに使うイベント名を tracker から取得するようにする

### DIFF
--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -58,7 +58,7 @@ export const tracker = (nodecg: NodeCG) => {
 			const res = await requestSearch<typeof EventSample>("event");
 			const event = res.find((e) => e.pk === trackerConfig.event);
 
-			eventName = event?.fields.name || "";
+			eventName = event?.fields.name || null;
 
 			const total = event?.fields.amount;
 			donationTotalRep.value = total;

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -16,6 +16,12 @@ type CommentDonation = typeof DonationSample[number] & {
 	fields: {comment: string};
 };
 
+let eventName: string = "";
+
+export const getEventName = () => {
+	return eventName;
+};
+
 export const tracker = (nodecg: NodeCG) => {
 	const log = new nodecg.Logger("tracker");
 	const trackerConfig = nodecg.bundleConfig.tracker;
@@ -47,11 +53,14 @@ export const tracker = (nodecg: NodeCG) => {
 		return res;
 	};
 
-	const updateTotal = async () => {
+	const updateEventData = async () => {
 		try {
 			const res = await requestSearch<typeof EventSample>("event");
-			const total = res.find((e) => e.pk === trackerConfig.event)?.fields
-				.amount;
+			const event = res.find((e) => e.pk === trackerConfig.event);
+
+			eventName = event?.fields.name || "";
+
+			const total = event?.fields.amount;
 			donationTotalRep.value = total;
 		} catch (error) {
 			log.error(error);
@@ -226,12 +235,12 @@ export const tracker = (nodecg: NodeCG) => {
 		}
 	};
 
-	updateTotal();
+	updateEventData();
 	updateRuns();
 	updateBids();
 	updateDonations();
 	setInterval(() => {
-		updateTotal();
+		updateEventData();
 		updateRuns();
 		updateBids();
 		updateDonations();

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -16,7 +16,7 @@ type CommentDonation = typeof DonationSample[number] & {
 	fields: {comment: string};
 };
 
-let eventName: string = "";
+let eventName: string | null = null;
 
 export const getEventName = () => {
 	return eventName;

--- a/src/extension/twitch.ts
+++ b/src/extension/twitch.ts
@@ -6,7 +6,7 @@ import {
 import {ApiClient, HelixUser} from "@twurple/api";
 import express from "express";
 import {NodeCG} from "./nodecg";
-import {getEventName} from "./tracker";
+import * as tracker from "./tracker";
 
 export const twitch = (nodecg: NodeCG) => {
 	const log = new nodecg.Logger("twitch");
@@ -110,7 +110,12 @@ export const twitch = (nodecg: NodeCG) => {
 			if (!newRun) {
 				return;
 			}
-			const title = `${newRun.title} : ${getEventName()}`;
+			const eventName = tracker.getEventName();
+			if (!eventName) {
+				log.warn("Skip to update twitch title because event name is not set.");
+				return;
+			}
+			const title = `${newRun.title} : ${tracker.getEventName()}`;
 			if (lastUpdatedTitle === title) {
 				return;
 			}

--- a/src/extension/twitch.ts
+++ b/src/extension/twitch.ts
@@ -6,6 +6,7 @@ import {
 import {ApiClient, HelixUser} from "@twurple/api";
 import express from "express";
 import {NodeCG} from "./nodecg";
+import {getEventName} from "./tracker";
 
 export const twitch = (nodecg: NodeCG) => {
 	const log = new nodecg.Logger("twitch");
@@ -109,7 +110,7 @@ export const twitch = (nodecg: NodeCG) => {
 			if (!newRun) {
 				return;
 			}
-			const title = `RTA in Japan Winter 2022: ${newRun.title}`;
+			const title = `${newRun.title} : ${getEventName()}`;
 			if (lastUpdatedTitle === title) {
 				return;
 			}


### PR DESCRIPTION
- issue: https://github.com/RTAinJapan/rtainjapan-layouts/issues/632
- 10秒に一回のイベント情報更新処理でイベント名を取得するように変更
- dashboard, graphics からの操作が不要なデータなので extension 内の変数で保存するので十分そうでした

resolve #632