### PR TITLE
ゲーム画面にTwitter表示機能を追加

### DIFF
--- a/src/browser/graphics/components/sponsor/index.tsx
+++ b/src/browser/graphics/components/sponsor/index.tsx
@@ -1,30 +1,77 @@
 import gsap from "gsap";
-import {CSSProperties, FunctionComponent, useEffect, useRef} from "react";
+import {CSSProperties, FunctionComponent, useEffect, useRef, useState} from "react";
 import {useReplicant} from "../../../use-replicant";
 import {background} from "../../styles/colors";
-import {swipeEnter, swipeExit} from "../lib/blur-swipe";
+import { swipeEnter, swipeExit } from "../lib/blur-swipe";
+import {Tweets} from "../../../../nodecg/generated/tweets";
+import iconTwitter from "../../images/icon/icon_twitter.svg";
+import { ThinText } from "../lib/text";
 
 export const Sponsor: FunctionComponent<{
 	style?: CSSProperties;
 	kind: "vertical" | "horizontal";
+	twitterSmall?: boolean;
 }> = (props) => {
 	const assets = useReplicant(`assets:sponsor-${props.kind}`);
 	const sponsorRef = useRef<HTMLImageElement>(null);
+	const twitterRef = useRef<HTMLImageElement>(null);
+	const containerRef = useRef<HTMLImageElement>(null);
+	const [user, setUser] = useState("");
+	const [text, setText] = useState("");
+	let tl = gsap.timeline();
+	const [currentSponsor, setCurrentSponsor] = useState(0);
 
 	useEffect(() => {
 		if (!assets) {
 			return;
 		}
-		const tl = gsap.timeline({repeat: -1});
-		for (const asset of assets) {
-			tl.set(sponsorRef.current, {attr: {src: asset.url}});
-			tl.add(swipeEnter(sponsorRef), "<+=0.3");
-			tl.add(swipeExit(sponsorRef), "<+=40");
-		}
+		const initialize = () => {
+			tl = gsap.timeline();
+			const sponsorUrl = assets[currentSponsor]?.url;
+			if (!sponsorUrl) {
+				return;
+			}
+
+			if (text) {
+				tl.set(containerRef.current, { maskImage: "linear-gradient(to right, rgba(0,0,0,1) -20%, rgba(0,0,0,0) 0%)" });
+				tl.set(twitterRef.current, {opacity: 1});
+				tl.add(swipeEnter(containerRef), "<+=0.3");
+				tl.add(swipeExit(containerRef), "<+=40");
+				tl.set(twitterRef.current, {opacity: 0});
+				tl.call(() => {
+					setUser("");
+					setText("");
+				});
+			}
+
+			tl.set(containerRef.current, { maskImage: "linear-gradient(to right, rgba(0,0,0,1) -20%, rgba(0,0,0,0) 0%)" });
+			tl.set(sponsorRef.current, {opacity: 1});
+			tl.set(sponsorRef.current, { attr: { src: sponsorUrl } });
+			tl.add(swipeEnter(containerRef), "<+=0.3");
+			tl.add(swipeExit(containerRef), "<+=40");
+
+			tl.set(sponsorRef.current, {opacity: 0});
+			tl.call(() => {
+				setCurrentSponsor((assets.length - 1) <= currentSponsor ? 0 : (currentSponsor + 1));
+				initialize();
+			});
+		};
+
+		const listener = (tweet: Tweets[number]) => {
+			tl.call(() => {
+				setUser(tweet.user.screenName);
+				setText(tweet.text);
+			});
+		};
+
+		initialize();
+
+		nodecg.listenFor("showTweet", listener);
 		return () => {
 			tl.kill();
+			nodecg.unlisten("showTweet", listener);
 		};
-	}, [assets]);
+	}, [assets, tl]);
 
 	return (
 		<div
@@ -39,15 +86,62 @@ export const Sponsor: FunctionComponent<{
 				...props.style,
 			}}
 		>
-			<img
-				ref={sponsorRef}
+			<div
+				ref={containerRef}
 				style={{
-					placeSelf: "center",
-					gridRow: "1 / 2",
-					gridColumn: "1 / 2",
+					display: "grid",
+					placeContent: "stretch",
 					willChange: "-webkit-mask-image",
 				}}
-			></img>
+			>
+				<img
+					ref={sponsorRef}
+					style={{
+						placeSelf: "center",
+						gridRow: "1 / 2",
+						gridColumn: "1 / 2",
+					}}
+				></img>
+				<div
+					style={{
+						placeSelf: "center",
+						gridRow: "1 / 2",
+						gridColumn: "1 / 2",
+						opacity: 0,
+						width: props.twitterSmall ? "380px" : "420px",
+					}}
+					ref={twitterRef}
+				>
+					<div
+						style={{
+							display: "grid",
+							gridTemplateColumns: "auto auto",
+							justifyContent: "start",
+							alignItems: "end",
+							justifyItems: "start",
+							marginBottom: "20px",
+						}}
+					>
+						<img
+							src={iconTwitter}
+							height={24}
+							width={24}
+							style={{margin: "0 5px 0 15px"}}
+						></img>
+						<ThinText style={{fontSize: "20px"}}>{user}</ThinText>
+					</div>
+					<ThinText
+						style={{
+							fontSize: "18px",
+							lineHeight: "30px",
+							whiteSpace: "normal",
+							wordBreak: "break-all",
+						}}
+					>
+						{text}
+					</ThinText>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/src/browser/graphics/views/game-scene/templates/L420.tsx
+++ b/src/browser/graphics/views/game-scene/templates/L420.tsx
@@ -16,6 +16,7 @@ export const TemplateL420: FunctionComponent<{
 		cameraHeight: "300px",
 		cameraHeightRace: "300px",
 		nameplateWidth: "390px",
+		twitterSmall: true,
 	});
 	return (
 		<div

--- a/src/browser/graphics/views/game-scene/templates/vertical-gameinfo.tsx
+++ b/src/browser/graphics/views/game-scene/templates/vertical-gameinfo.tsx
@@ -11,6 +11,7 @@ export const useVerticalGameInfo = (props: {
 	cameraHeightRace: string;
 	nameplateWidth: string;
 	limitOneCommentator?: boolean;
+	twitterSmall?: boolean;
 }) => {
 	const commentators = useCommentators();
 
@@ -67,7 +68,7 @@ export const useVerticalGameInfo = (props: {
 			<Camera style={{placeSelf: "stretch"}}></Camera>
 			{runnerNamePlate}
 			{commentatorNamePlate}
-			<Sponsor kind='vertical' style={{placeSelf: "stretch"}}></Sponsor>
+			<Sponsor kind='vertical' style={{ placeSelf: "stretch" }} twitterSmall={props.twitterSmall}></Sponsor>
 		</div>
 	);
 };


### PR DESCRIPTION
# Issue
- なし

# 概要
- ゲーム画面のスポンサー枠にTwitter表示を行えるようにした
  - 現在表示中のスポンサーの表示が終わった後に表示される
  - 表示時間は現状スポンサーと同じく40秒
- 横枠狭めのスポンサー枠はTwitter表示枠が小さいので関連コンポーネントにprops追加

# その他気になること
- 要件通りのレイアウトになっているかが若干不安（特にフォント周り）