### PR TITLE
trackerと解説の紐づけにpkを使うようにした

### DIFF
--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -128,7 +128,7 @@ export const tracker = (nodecg: NodeCG) => {
 						}),
 						commentators: commentators
 							.filter((commentator) => {
-								return commentator.gameCategory.startsWith(run.fields.name);
+								return commentator.gameCategory.endsWith(`- ${run.pk}`);
 							})
 							.map((commentator) => {
 								return {


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/644

# 概要
「担当ゲームカテゴリ」は「ゲーム名 - カテゴリ名 - trackerのpk」という形式になっているため、それに対応したfilterに修正