### PR TITLE
クレジットの内容をダッシュボードから確認できるようにする

### DIFF
--- a/src/browser/dashboard/views/credit-control.tsx
+++ b/src/browser/dashboard/views/credit-control.tsx
@@ -38,12 +38,15 @@ const Credit: React.FC<{
 	</Accordion>
 );
 
+const sortNames = (names: string[]) => {
+	return [...names].sort((a, b) => a.localeCompare(b, "ja"));
+};
+
 const App = () => {
-	const runnersRep = useReplicant("runners");
-	const runner = runnersRep ?? [];
-	const staff = nodecg.bundleConfig.endCredit?.staff ?? [];
-	const partners = nodecg.bundleConfig.endCredit?.partners ?? [];
-	const volunteers = nodecg.bundleConfig.endCredit?.volunteers ?? [];
+	const runner = sortNames(useReplicant("runners") ?? []);
+	const staff = sortNames(nodecg.bundleConfig.endCredit?.staff ?? []);
+	const partners = sortNames(nodecg.bundleConfig.endCredit?.partners ?? []);
+	const volunteers = sortNames(nodecg.bundleConfig.endCredit?.volunteers ?? []);
 	const text = nodecg.bundleConfig.endCredit?.text ?? [];
 
 	return (

--- a/src/browser/dashboard/views/credit-control.tsx
+++ b/src/browser/dashboard/views/credit-control.tsx
@@ -1,10 +1,57 @@
 import "modern-normalize";
 import ReactDOM from "react-dom";
+import {withStyles} from "@material-ui/core/styles";
+import Accordion from "@material-ui/core/Accordion";
+import MuiAccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import Typography from "@material-ui/core/Typography";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import {useReplicant} from "../../use-replicant";
+
+const AccordionSummary = withStyles({
+	root: {
+		backgroundColor: "rgba(0, 0, 0, .1)",
+		borderBottom: "1px solid rgba(0, 0, 0, .125)",
+	},
+	expanded: {},
+})(MuiAccordionSummary);
+
+const Credit: React.FC<{
+	title: string;
+	names: string[];
+}> = (props) => (
+	<Accordion>
+		<AccordionSummary
+			expandIcon={<ExpandMoreIcon />}
+			aria-controls='panel1a-content'
+			id='panel1a-header'
+		>
+			<Typography>{props.title}</Typography>
+		</AccordionSummary>
+		<AccordionDetails>
+			<ul>
+				{props.names.map((name, index) => (
+					<li key={index}>{name}</li>
+				))}
+			</ul>
+		</AccordionDetails>
+	</Accordion>
+);
 
 const App = () => {
+	const runnersRep = useReplicant("runners");
+	const runner = runnersRep ?? [];
+	const staff = nodecg.bundleConfig.endCredit?.staff ?? [];
+	const partners = nodecg.bundleConfig.endCredit?.partners ?? [];
+	const volunteers = nodecg.bundleConfig.endCredit?.volunteers ?? [];
+	const text = nodecg.bundleConfig.endCredit?.text ?? [];
+
 	return (
 		<div
 			style={{
+				display: "grid",
+				gridAutoFlow: "row",
+				rowGap: "16px",
 				padding: "8px",
 			}}
 		>
@@ -17,6 +64,11 @@ const App = () => {
 			>
 				エンドロール開始
 			</button>
+			<Credit title='Runners' names={runner} />
+			<Credit title='Staff' names={staff} />
+			<Credit title='Partners' names={partners} />
+			<Credit title='Volunteers' names={volunteers} />
+			<Credit title='Text' names={text} />
 		</div>
 	);
 };


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/640

# 概要
- クレジットの内容は再生してみるまでわからなかったのでダッシュボードから見れるよう修正
![image](https://user-images.githubusercontent.com/13300790/233813139-25986571-b4a3-4289-b819-ac7a61dd561a.png)

