### PR TITLE
カウントダウン作動中の時間変更を無効化、時間表示を24時間表記に修正

### DIFF
--- a/src/browser/dashboard/views/countdown.tsx
+++ b/src/browser/dashboard/views/countdown.tsx
@@ -17,13 +17,14 @@ const App = () => {
 			<label>開始時間</label>
 			<input
 				type='datetime-local'
-				value={moment(countdown?.endTime).format("yyyy-MM-DDThh:mm")}
+				value={moment(countdown?.endTime).format("yyyy-MM-DDTHH:mm")}
 				onChange={(e) => {
 					if (countdownRep.value) {
 						const time = new Date(e.target.value);
 						countdownRep.value.endTime = time.getTime();
 					}
 				}}
+				disabled={countdown?.state === "running"}
 			/>
 			<button
 				onClick={() => {


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/617

# 概要
- カウントダウン中にダッシュボードからカレンダーを開き、時間変更できてしまっていたので作動中はdisabled化するようにした
- カレンダーで時間指定後、フォーム内表記が12時間表記になっていたのを24時間表記に修正


