### PR TITLE
重複したチェックリストを弾く用に修正

### DIFF
--- a/src/extension/checklist.ts
+++ b/src/extension/checklist.ts
@@ -11,7 +11,7 @@ export const checklist = (nodecg: NodeCG) => {
 		return;
 	}
 
-	const defaultChecklist = checklist.map((item) => ({
+	const defaultChecklist = [...new Set(checklist)].map((item) => ({
 		name: item,
 		complete: false,
 	}));


### PR DESCRIPTION
# 概要
- チェックリストは項目名そのものでオンオフを管理するロジックになっていたので、同名のチェックリストを追加すると挙動がおかしくなっていた
- とりあえずデータ型とかが変わると面倒かなと思い重複したチェックリストは削除するように