### PR TITLE
breakの楽曲ライセンス情報をconfig化

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -63,7 +63,9 @@
 			"required": ["clientId", "clientSecret"],
 			"properties": {
 				"clientId": {"type": "string"},
-				"clientSecret": {"type": "string"}
+				"clientSecret": {"type": "string"},
+				"textPrefix": {"type": "string", "default": ""},
+				"textSuffix": {"type": "string", "default": ""}
 			}
 		},
 		"googleApiKey": {"type": "string"},

--- a/src/browser/graphics/components/music.tsx
+++ b/src/browser/graphics/components/music.tsx
@@ -7,7 +7,8 @@ import {ThinText} from "./lib/text";
 
 export const Music = () => {
 	const spotify = useReplicant("spotify");
-	const text = `${spotify?.currentTrack?.name} - ${spotify?.currentTrack?.artists} music by サクラチル`;
+	// prettier-ignore
+	const text = `${nodecg.bundleConfig.spotify?.textPrefix ?? ""} ${spotify?.currentTrack?.name} - ${spotify?.currentTrack?.artists} ${nodecg.bundleConfig.spotify?.textSuffix ?? ""}`;
 	const ref = useRef<HTMLDivElement>(null);
 	const [shownText, setShownText] = useState("");
 


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/669

# 概要
- ライセンスとして付加してた情報をbundleConfigにした。
  - 前につけたいときと後ろにつけたい時に対応できるようにした。 
  - configのkey未指定の場合は空文字として扱う

# サンプル
- key未指定
![image](https://user-images.githubusercontent.com/3125070/234139583-bd693d26-6d86-42df-a34a-61931eb6a365.png)

```js
	"spotify": {
		"clientId": "xxxxxx",
		"clientSecret": "xxxxxx"
	},
```

- 両方指定
![image](https://user-images.githubusercontent.com/3125070/234139598-f9a5e057-fe1b-483f-989a-1ac240c7ac05.png)

```js
	"spotify": {
		"clientId": "xxxxxx",
		"clientSecret": "xxxxxx",
		"textPrefix": "[うた]",
		"textSuffix": "music by 誰か"
	},
```

- 空文字で両方指定
![image](https://user-images.githubusercontent.com/3125070/234139616-2fcd4d40-6dfe-475e-940c-c933a89f570d.png)

```js
	"spotify": {
		"clientId": "xxxxxx",
		"clientSecret": "xxxxxx",
		"textPrefix": "",
		"textSuffix": ""
	},
```