### PR TITLE
Spotifyの楽曲切り替えアニメーション実装

### DIFF
--- a/src/browser/graphics/components/music.tsx
+++ b/src/browser/graphics/components/music.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import gsap, {Power2} from "gsap";
 import {useEffect, useRef, useState} from "react";
 import {useReplicant} from "../../use-replicant";
@@ -11,9 +10,9 @@ export const Music = () => {
 	const text = `${spotify?.currentTrack?.name} - ${spotify?.currentTrack?.artists} music by サクラチル`;
 	const ref = useRef<HTMLDivElement>(null);
 	const [shownText, setShownText] = useState("");
-	const tl = gsap.timeline();
 
 	useEffect(() => {
+		const tl = gsap.timeline();
 		tl.to(ref.current, {
 			x: ref.current?.getBoundingClientRect().width ?? 0,
 			duration: 1,
@@ -22,28 +21,22 @@ export const Music = () => {
 		tl.set(ref.current, {opacity: 0});
 		tl.call(() => {
 			setShownText(text);
+			tl.set(ref.current, {opacity: 1});
+			tl.fromTo(
+				ref.current,
+				{x: ref.current?.getBoundingClientRect().width ?? 0},
+				{
+					x: 0,
+					duration: 1,
+					ease: Power2.easeOut,
+				},
+				"+=0.2",
+			);
 		});
 		return () => {
 			tl.kill();
 		};
 	}, [text]);
-
-	useEffect(() => {
-		tl.set(ref.current, {opacity: 1});
-		tl.fromTo(
-			ref.current,
-			{x: ref.current?.getBoundingClientRect().width ?? 0},
-			{
-				x: 0,
-				duration: 1,
-				ease: Power2.easeOut,
-			},
-			"+=0.2",
-		);
-		return () => {
-			tl.kill();
-		};
-	}, [shownText]);
 
 	return (
 		<div

--- a/src/browser/graphics/components/music.tsx
+++ b/src/browser/graphics/components/music.tsx
@@ -1,4 +1,5 @@
-import gsap from "gsap";
+/* eslint-disable react-hooks/exhaustive-deps */
+import gsap, {Power2} from "gsap";
 import {useEffect, useRef, useState} from "react";
 import {useReplicant} from "../../use-replicant";
 import musicIcon from "../images/icon/icon_music.svg";
@@ -10,18 +11,39 @@ export const Music = () => {
 	const text = `${spotify?.currentTrack?.name} - ${spotify?.currentTrack?.artists} music by サクラチル`;
 	const ref = useRef<HTMLDivElement>(null);
 	const [shownText, setShownText] = useState("");
+	const tl = gsap.timeline();
 
 	useEffect(() => {
-		const tl = gsap.timeline();
-		tl.fromTo(ref.current, {opacity: 1}, {opacity: 0, duration: 0.5});
+		tl.to(ref.current, {
+			x: ref.current?.getBoundingClientRect().width ?? 0,
+			duration: 1,
+			ease: Power2.easeOut,
+		});
+		tl.set(ref.current, {opacity: 0});
 		tl.call(() => {
 			setShownText(text);
 		});
-		tl.fromTo(ref.current, {opacity: 0}, {opacity: 1, duration: 0.5}, "+=0.2");
 		return () => {
 			tl.kill();
 		};
 	}, [text]);
+
+	useEffect(() => {
+		tl.set(ref.current, {opacity: 1});
+		tl.fromTo(
+			ref.current,
+			{x: ref.current?.getBoundingClientRect().width ?? 0},
+			{
+				x: 0,
+				duration: 1,
+				ease: Power2.easeOut,
+			},
+			"+=0.2",
+		);
+		return () => {
+			tl.kill();
+		};
+	}, [shownText]);
 
 	return (
 		<div

--- a/src/browser/graphics/components/music.tsx
+++ b/src/browser/graphics/components/music.tsx
@@ -63,6 +63,8 @@ export const Music = () => {
 				gridTemplateColumns: "24px auto",
 				gap: "10px",
 				placeItems: "center",
+				placeContent: "center",
+				minWidth: "440px",
 			}}
 		>
 			<img src={musicIcon} height={24} width={24}></img>


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/597

# 概要
- 楽曲変更時は今までフェードイン/アウトだったのをTwitterと同じアニメーションに変更(仕様書準拠)
- 文字数が少ない時に枠の横幅が最小値（スポンサー枠と同じ）以下にならないようにCSS修正
- 文字数が少ない時にアイコンと文字が離れていたのを修正

# 表示例
![ダウンロード (1)](https://user-images.githubusercontent.com/13300790/234162951-247b6303-87f5-4487-bfb7-09bfe6d1e258.gif)
