### PR TITLE
お知らせを編集可能にして、複数表示できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,14 @@
 				"width": 3,
 				"headerColor": "#00BEBE",
 				"workspace": "2-misc"
+			},
+			{
+				"name": "announcements",
+				"title": "お知らせ",
+				"file": "announcements.html",
+				"width": 4,
+				"headerColor": "#00BEBE",
+				"workspace": "2-misc"
 			}
 		],
 		"graphics": [

--- a/schemas/announcements.json
+++ b/schemas/announcements.json
@@ -1,15 +1,15 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
+	"$schema": "http://json-schema.org/draft-04/schema",
 
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "title": { "type": "string" },
-            "content": { "type": "string" }
-        },
-        "additionalProperties": false,
-        "required": [ "title", "content" ]
-    },
-    "default": []
+	"type": "array",
+	"items": {
+		"type": "object",
+		"properties": {
+			"title": {"type": "string"},
+			"content": {"type": "string"}
+		},
+		"additionalProperties": false,
+		"required": ["title", "content"]
+	},
+	"default": []
 }

--- a/schemas/announcements.json
+++ b/schemas/announcements.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "title": { "type": "string" },
+            "content": { "type": "string" }
+        },
+        "additionalProperties": false,
+        "required": [ "title", "content" ]
+    },
+    "default": []
+}

--- a/src/browser/dashboard/components/announcements/announcement-add.tsx
+++ b/src/browser/dashboard/components/announcements/announcement-add.tsx
@@ -1,0 +1,71 @@
+import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText'
+import AddIcon from '@material-ui/icons/Add'
+import { useState } from 'react';
+import { Announcements } from '../../../../nodecg/generated';
+
+type Announcement = Announcements[number]
+
+type Props = {
+    onSubmit: (announcement: Announcement, onSuccess: () => void) => void;
+};
+
+type ButtonProps = Pick<IconButtonProps, 'onClick'>;
+
+const AddButton = (props: ButtonProps) => {
+    return (
+        <IconButton {...props}>
+            <AddIcon />
+        </IconButton>
+    )
+}
+
+export const AnnouncementAdd = ({ onSubmit }: Props) => {
+
+    const [ announcement, setAnnouncement ] = useState<Announcement>({
+        title: '',
+        content: '',
+    });
+
+    const clearInputs = () => {
+        setAnnouncement({
+            title: '',
+            content: '',
+        })
+    };
+
+    return (
+        <ListItem>
+            <ListItemText
+				primary={
+                    <input
+                        value={announcement.title}
+                        onChange={(e) => {
+                            setAnnouncement({
+                                ... announcement,
+                                title: e.currentTarget.value
+                            })
+                        }}
+                        placeholder='タイトル'
+                    />}
+				secondary={
+                    <input
+                        value={announcement.content}
+                        onChange={(e) => {
+                            setAnnouncement({
+                                ... announcement,
+                                content: e.currentTarget.value,
+                            })
+                        }}
+                        placeholder='内容'
+                        size={50}
+                    />}
+            />
+            <ListItemSecondaryAction>
+                <AddButton onClick={() => { onSubmit(announcement, () => {clearInputs()}) }} />
+            </ListItemSecondaryAction>
+        </ListItem>
+    )
+}

--- a/src/browser/dashboard/components/announcements/announcement-add.tsx
+++ b/src/browser/dashboard/components/announcements/announcement-add.tsx
@@ -1,71 +1,78 @@
-import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-import ListItemText from '@material-ui/core/ListItemText'
-import AddIcon from '@material-ui/icons/Add'
-import { useState } from 'react';
-import { Announcements } from '../../../../nodecg/generated';
+import IconButton, {IconButtonProps} from "@material-ui/core/IconButton";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import AddIcon from "@material-ui/icons/Add";
+import {useState} from "react";
+import {Announcements} from "../../../../nodecg/generated";
 
-type Announcement = Announcements[number]
+type Announcement = Announcements[number];
 
 type Props = {
-    onSubmit: (announcement: Announcement, onSuccess: () => void) => void;
+	onSubmit: (announcement: Announcement, onSuccess: () => void) => void;
 };
 
-type ButtonProps = Pick<IconButtonProps, 'onClick'>;
+type ButtonProps = Pick<IconButtonProps, "onClick">;
 
 const AddButton = (props: ButtonProps) => {
-    return (
-        <IconButton {...props}>
-            <AddIcon />
-        </IconButton>
-    )
-}
+	return (
+		<IconButton {...props}>
+			<AddIcon />
+		</IconButton>
+	);
+};
 
-export const AnnouncementAdd = ({ onSubmit }: Props) => {
+export const AnnouncementAdd = ({onSubmit}: Props) => {
+	const [announcement, setAnnouncement] = useState<Announcement>({
+		title: "",
+		content: "",
+	});
 
-    const [ announcement, setAnnouncement ] = useState<Announcement>({
-        title: '',
-        content: '',
-    });
+	const clearInputs = () => {
+		setAnnouncement({
+			title: "",
+			content: "",
+		});
+	};
 
-    const clearInputs = () => {
-        setAnnouncement({
-            title: '',
-            content: '',
-        })
-    };
-
-    return (
-        <ListItem>
-            <ListItemText
+	return (
+		<ListItem>
+			<ListItemText
 				primary={
-                    <input
-                        value={announcement.title}
-                        onChange={(e) => {
-                            setAnnouncement({
-                                ... announcement,
-                                title: e.currentTarget.value
-                            })
-                        }}
-                        placeholder='タイトル'
-                    />}
+					<input
+						value={announcement.title}
+						onChange={(e) => {
+							setAnnouncement({
+								...announcement,
+								title: e.currentTarget.value,
+							});
+						}}
+						placeholder='タイトル'
+					/>
+				}
 				secondary={
-                    <input
-                        value={announcement.content}
-                        onChange={(e) => {
-                            setAnnouncement({
-                                ... announcement,
-                                content: e.currentTarget.value,
-                            })
-                        }}
-                        placeholder='内容'
-                        size={50}
-                    />}
-            />
-            <ListItemSecondaryAction>
-                <AddButton onClick={() => { onSubmit(announcement, () => {clearInputs()}) }} />
-            </ListItemSecondaryAction>
-        </ListItem>
-    )
-}
+					<input
+						value={announcement.content}
+						onChange={(e) => {
+							setAnnouncement({
+								...announcement,
+								content: e.currentTarget.value,
+							});
+						}}
+						placeholder='内容'
+						size={50}
+					/>
+				}
+			/>
+			<ListItemSecondaryAction>
+				<AddButton
+					onClick={() => {
+						onSubmit(announcement, () => {
+							clearInputs();
+						});
+					}}
+				/>
+			</ListItemSecondaryAction>
+		</ListItem>
+	);
+};

--- a/src/browser/dashboard/components/announcements/announcement-item.tsx
+++ b/src/browser/dashboard/components/announcements/announcement-item.tsx
@@ -1,115 +1,139 @@
-import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-import ListItemText from '@material-ui/core/ListItemText'
-import Typography from '@material-ui/core/Typography';
-import CheckIcon from '@material-ui/icons/Check'
-import EditIcon from '@material-ui/icons/Edit'
-import DeleteIcon from '@material-ui/icons/Delete'
-import UndoIcon from '@material-ui/icons/Undo'
-import { useEffect, useState } from 'react';
-import { Announcements } from '../../../../nodecg/generated';
+import IconButton, {IconButtonProps} from "@material-ui/core/IconButton";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import Typography from "@material-ui/core/Typography";
+import CheckIcon from "@material-ui/icons/Check";
+import EditIcon from "@material-ui/icons/Edit";
+import DeleteIcon from "@material-ui/icons/Delete";
+import UndoIcon from "@material-ui/icons/Undo";
+import {useEffect, useState} from "react";
+import {Announcements} from "../../../../nodecg/generated";
 
-type Announcement = Announcements[number]
+type Announcement = Announcements[number];
 
 type Props = {
-    announcement: Announcement;
-    onSubmit: (announcement: Announcement, onSuccess: () => void ) => void;
-    onDelete: (onSuccess: () => void) => void;
+	announcement: Announcement;
+	onSubmit: (announcement: Announcement, onSuccess: () => void) => void;
+	onDelete: (onSuccess: () => void) => void;
 };
 
-type ButtonProps = Pick<IconButtonProps, 'onClick'>;
+type ButtonProps = Pick<IconButtonProps, "onClick">;
 
 const EditButton = (props: ButtonProps) => {
-    return (
-        <IconButton {...props}>
-            <EditIcon />
-        </IconButton>
-    )
-}
+	return (
+		<IconButton {...props}>
+			<EditIcon />
+		</IconButton>
+	);
+};
 
 const DeleteButton = (props: ButtonProps) => {
-    return (
-        <IconButton {...props}>
-            <DeleteIcon />
-        </IconButton>
-    )
-}
+	return (
+		<IconButton {...props}>
+			<DeleteIcon />
+		</IconButton>
+	);
+};
 
 const SubmitButton = (props: ButtonProps) => {
-    return (
-        <IconButton {...props}>
-            <CheckIcon />
-        </IconButton>
-    )
-}
+	return (
+		<IconButton {...props}>
+			<CheckIcon />
+		</IconButton>
+	);
+};
 
 const UndoButton = (props: ButtonProps) => {
-    return (
-        <IconButton {...props}>
-            <UndoIcon />
-        </IconButton>
-    )
-}
+	return (
+		<IconButton {...props}>
+			<UndoIcon />
+		</IconButton>
+	);
+};
 
-export const AnnouncementItem = ({ announcement: propAnnouncement, onSubmit, onDelete }: Props) => {
+export const AnnouncementItem = ({
+	announcement: propAnnouncement,
+	onSubmit,
+	onDelete,
+}: Props) => {
+	const [edit, setEdit] = useState<boolean>(false);
+	const [announcement, setAnnouncement] =
+		useState<Announcement>(propAnnouncement);
 
-    const [ edit, setEdit ] = useState<boolean>(false);
-    const [ announcement, setAnnouncement ] = useState<Announcement>(propAnnouncement);
+	useEffect(() => {
+		setAnnouncement(propAnnouncement);
+	}, [propAnnouncement]);
 
-    useEffect(() => {
-        setAnnouncement(propAnnouncement);
-    }, [propAnnouncement]);
-
-    return (
-        <ListItem>
-            <ListItemText
-				primary={ edit ? (
-                    <input
-                        value={announcement.title}
-                        onChange={(e) => {
-                            setAnnouncement({
-                                ... announcement,
-                                title: e.currentTarget.value,
-                            })
-                        }}
-                    />
-                ) : ( announcement.title )}
-				secondary={ edit ? (
-                    <input
-                        value={announcement.content}
-                        onChange={(e) => {
-                            setAnnouncement({
-                                ... announcement,
-                                content: e.currentTarget.value,
-                            })
-                        }}
-                        size={50}
-                    />
-                ) : (<Typography variant='body2'>{announcement.content}</Typography>)}
-            />
-            <ListItemSecondaryAction>
-                {
-                    edit
-                    ? (
-                        <>
-                            <SubmitButton onClick={() => {onSubmit(announcement, () => { setEdit(false) })}} />
-                            /
-                            <UndoButton onClick={() => {
-                                setAnnouncement(propAnnouncement);
-                                setEdit(false);
-                            }} />
-                        </>
-                    )
-                    : (
-                        <>
-                            <EditButton onClick={() => { setEdit(true) }} />
-                            /
-                            <DeleteButton onClick={() => { onDelete(() => setEdit(false)) }} />
-                        </>
-                    )
-                }
-            </ListItemSecondaryAction>
-        </ListItem>
-    )
-}
+	return (
+		<ListItem>
+			<ListItemText
+				primary={
+					edit ? (
+						<input
+							value={announcement.title}
+							onChange={(e) => {
+								setAnnouncement({
+									...announcement,
+									title: e.currentTarget.value,
+								});
+							}}
+						/>
+					) : (
+						announcement.title
+					)
+				}
+				secondary={
+					edit ? (
+						<input
+							value={announcement.content}
+							onChange={(e) => {
+								setAnnouncement({
+									...announcement,
+									content: e.currentTarget.value,
+								});
+							}}
+							size={50}
+						/>
+					) : (
+						<Typography variant='body2'>{announcement.content}</Typography>
+					)
+				}
+			/>
+			<ListItemSecondaryAction>
+				{edit ? (
+					<>
+						<SubmitButton
+							onClick={() => {
+								onSubmit(announcement, () => {
+									setEdit(false);
+								});
+							}}
+						/>
+						/
+						<UndoButton
+							onClick={() => {
+								setAnnouncement(propAnnouncement);
+								setEdit(false);
+							}}
+						/>
+					</>
+				) : (
+					<>
+						<EditButton
+							onClick={() => {
+								setEdit(true);
+							}}
+						/>
+						/
+						<DeleteButton
+							onClick={() => {
+								onDelete(() => setEdit(false));
+							}}
+						/>
+					</>
+				)}
+			</ListItemSecondaryAction>
+		</ListItem>
+	);
+};

--- a/src/browser/dashboard/components/announcements/announcement-item.tsx
+++ b/src/browser/dashboard/components/announcements/announcement-item.tsx
@@ -1,0 +1,115 @@
+import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText'
+import Typography from '@material-ui/core/Typography';
+import CheckIcon from '@material-ui/icons/Check'
+import EditIcon from '@material-ui/icons/Edit'
+import DeleteIcon from '@material-ui/icons/Delete'
+import UndoIcon from '@material-ui/icons/Undo'
+import { useEffect, useState } from 'react';
+import { Announcements } from '../../../../nodecg/generated';
+
+type Announcement = Announcements[number]
+
+type Props = {
+    announcement: Announcement;
+    onSubmit: (announcement: Announcement, onSuccess: () => void ) => void;
+    onDelete: (onSuccess: () => void) => void;
+};
+
+type ButtonProps = Pick<IconButtonProps, 'onClick'>;
+
+const EditButton = (props: ButtonProps) => {
+    return (
+        <IconButton {...props}>
+            <EditIcon />
+        </IconButton>
+    )
+}
+
+const DeleteButton = (props: ButtonProps) => {
+    return (
+        <IconButton {...props}>
+            <DeleteIcon />
+        </IconButton>
+    )
+}
+
+const SubmitButton = (props: ButtonProps) => {
+    return (
+        <IconButton {...props}>
+            <CheckIcon />
+        </IconButton>
+    )
+}
+
+const UndoButton = (props: ButtonProps) => {
+    return (
+        <IconButton {...props}>
+            <UndoIcon />
+        </IconButton>
+    )
+}
+
+export const AnnouncementItem = ({ announcement: propAnnouncement, onSubmit, onDelete }: Props) => {
+
+    const [ edit, setEdit ] = useState<boolean>(false);
+    const [ announcement, setAnnouncement ] = useState<Announcement>(propAnnouncement);
+
+    useEffect(() => {
+        setAnnouncement(propAnnouncement);
+    }, [propAnnouncement]);
+
+    return (
+        <ListItem>
+            <ListItemText
+				primary={ edit ? (
+                    <input
+                        value={announcement.title}
+                        onChange={(e) => {
+                            setAnnouncement({
+                                ... announcement,
+                                title: e.currentTarget.value,
+                            })
+                        }}
+                    />
+                ) : ( announcement.title )}
+				secondary={ edit ? (
+                    <input
+                        value={announcement.content}
+                        onChange={(e) => {
+                            setAnnouncement({
+                                ... announcement,
+                                content: e.currentTarget.value,
+                            })
+                        }}
+                        size={50}
+                    />
+                ) : (<Typography variant='body2'>{announcement.content}</Typography>)}
+            />
+            <ListItemSecondaryAction>
+                {
+                    edit
+                    ? (
+                        <>
+                            <SubmitButton onClick={() => {onSubmit(announcement, () => { setEdit(false) })}} />
+                            /
+                            <UndoButton onClick={() => {
+                                setAnnouncement(propAnnouncement);
+                                setEdit(false);
+                            }} />
+                        </>
+                    )
+                    : (
+                        <>
+                            <EditButton onClick={() => { setEdit(true) }} />
+                            /
+                            <DeleteButton onClick={() => { onDelete(() => setEdit(false)) }} />
+                        </>
+                    )
+                }
+            </ListItemSecondaryAction>
+        </ListItem>
+    )
+}

--- a/src/browser/dashboard/components/announcements/index.tsx
+++ b/src/browser/dashboard/components/announcements/index.tsx
@@ -1,0 +1,44 @@
+import List from '@material-ui/core/List';
+import styled from 'styled-components';
+import { useReplicant } from '../../../use-replicant'
+import { AnnouncementAdd } from './announcement-add';
+import { AnnouncementItem } from './announcement-item';
+
+const Container = styled.div``;
+
+const announcementsRep = nodecg.Replicant('announcements');
+
+export const Announcements = () => {
+    const announcements = useReplicant('announcements');
+
+    return (
+        <Container>
+            <List>
+                { announcements?.map((announcement, index) => (
+                    <AnnouncementItem
+                        key={index}
+                        announcement={announcement}
+                        onSubmit={(announcement, onSuccess) => {
+                            if (announcementsRep.value) {
+                                announcementsRep.value[index] = { ...announcement }
+                                onSuccess();
+                            }
+                        }}
+                        onDelete={(onSuccess) => {
+                            if (announcementsRep.value) {
+                                announcementsRep.value = [...announcements.slice(0, index), ...announcements.slice(index + 1)]
+                                onSuccess();
+                            }
+                        }}
+                    />
+                ))}
+                <AnnouncementAdd onSubmit={(announcement, onSuccess) => {
+                    if (announcementsRep.value && announcement.title && announcement.content) {
+                        announcementsRep.value.push(announcement);
+                        onSuccess();
+                    }
+                }} />
+            </List>
+        </Container>
+    )
+}

--- a/src/browser/dashboard/components/announcements/index.tsx
+++ b/src/browser/dashboard/components/announcements/index.tsx
@@ -1,44 +1,53 @@
-import List from '@material-ui/core/List';
-import styled from 'styled-components';
-import { useReplicant } from '../../../use-replicant'
-import { AnnouncementAdd } from './announcement-add';
-import { AnnouncementItem } from './announcement-item';
+import List from "@material-ui/core/List";
+import styled from "styled-components";
+import {useReplicant} from "../../../use-replicant";
+import {AnnouncementAdd} from "./announcement-add";
+import {AnnouncementItem} from "./announcement-item";
 
 const Container = styled.div``;
 
-const announcementsRep = nodecg.Replicant('announcements');
+const announcementsRep = nodecg.Replicant("announcements");
 
 export const Announcements = () => {
-    const announcements = useReplicant('announcements');
+	const announcements = useReplicant("announcements");
 
-    return (
-        <Container>
-            <List>
-                { announcements?.map((announcement, index) => (
-                    <AnnouncementItem
-                        key={index}
-                        announcement={announcement}
-                        onSubmit={(announcement, onSuccess) => {
-                            if (announcementsRep.value) {
-                                announcementsRep.value[index] = { ...announcement }
-                                onSuccess();
-                            }
-                        }}
-                        onDelete={(onSuccess) => {
-                            if (announcementsRep.value) {
-                                announcementsRep.value = [...announcements.slice(0, index), ...announcements.slice(index + 1)]
-                                onSuccess();
-                            }
-                        }}
-                    />
-                ))}
-                <AnnouncementAdd onSubmit={(announcement, onSuccess) => {
-                    if (announcementsRep.value && announcement.title && announcement.content) {
-                        announcementsRep.value.push(announcement);
-                        onSuccess();
-                    }
-                }} />
-            </List>
-        </Container>
-    )
-}
+	return (
+		<Container>
+			<List>
+				{announcements?.map((announcement, index) => (
+					<AnnouncementItem
+						key={index}
+						announcement={announcement}
+						onSubmit={(announcement, onSuccess) => {
+							if (announcementsRep.value) {
+								announcementsRep.value[index] = {...announcement};
+								onSuccess();
+							}
+						}}
+						onDelete={(onSuccess) => {
+							if (announcementsRep.value) {
+								announcementsRep.value = [
+									...announcements.slice(0, index),
+									...announcements.slice(index + 1),
+								];
+								onSuccess();
+							}
+						}}
+					/>
+				))}
+				<AnnouncementAdd
+					onSubmit={(announcement, onSuccess) => {
+						if (
+							announcementsRep.value &&
+							announcement.title &&
+							announcement.content
+						) {
+							announcementsRep.value.push(announcement);
+							onSuccess();
+						}
+					}}
+				/>
+			</List>
+		</Container>
+	);
+};

--- a/src/browser/dashboard/views/announcements.tsx
+++ b/src/browser/dashboard/views/announcements.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from "react-dom";
 import {createTheme, MuiThemeProvider} from "@material-ui/core";
 import "modern-normalize";
-import { Announcements } from '../components/announcements';
+import {Announcements} from "../components/announcements";
 
 const theme = createTheme();
 

--- a/src/browser/dashboard/views/announcements.tsx
+++ b/src/browser/dashboard/views/announcements.tsx
@@ -1,0 +1,16 @@
+import ReactDOM from "react-dom";
+import {createTheme, MuiThemeProvider} from "@material-ui/core";
+import "modern-normalize";
+import { Announcements } from '../components/announcements';
+
+const theme = createTheme();
+
+const App = () => {
+	return (
+		<MuiThemeProvider theme={theme}>
+			<Announcements />
+		</MuiThemeProvider>
+	);
+};
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/src/browser/graphics/views/omnibar.tsx
+++ b/src/browser/graphics/views/omnibar.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import {text} from "../styles/colors";
 import {
+	Announcements,
 	BidChallenge,
 	BidWar,
 	Donation,
@@ -447,13 +448,22 @@ const Omnibar = () => {
 		}
 	}, [rawDonationQueue]);
 
-	const oshiraseRef = useRef<HTMLDivElement>(null);
+	const rawAnnouncements = useReplicant('announcements');
+	const announcements = useRef<Announcements>([]);
+	useEffect(() => {
+		if (rawAnnouncements) {
+			announcements.current = rawAnnouncements;
+		}
+	}, [rawAnnouncements]);
+
 	const bidwarRef = useRef<HTMLDivElement>(null);
 	const bidChallengeRef = useRef<HTMLDivElement>(null);
 	const donationCommentRef = useRef<HTMLDivElement>(null);
 
-	const donateLink = useRef<HTMLDivElement>(null);
-	const twitchIncome = useRef<HTMLDivElement>(null);
+	const announceRowA = useRef<HTMLDivElement>(null);
+	const announceRowB = useRef<HTMLDivElement>(null);
+	const [announceA, setAnnounceA] = useState<Announcements[number]>();
+	const [announceB, setAnnounceB] = useState<Announcements[number]>();
 
 	const bidwarRowA = useRef<HTMLDivElement>(null);
 	const bidwarRowB = useRef<HTMLDivElement>(null);
@@ -472,29 +482,64 @@ const Omnibar = () => {
 
 	useEffect(() => {
 		let tl: gsap.core.Timeline;
+		let lastAnnouncement: Announcements[number] | undefined;
 
 		const initialize = (playOshiraseEnter: boolean) => {
 			tl = gsap.timeline();
+			
+			const currentAnnouncements = announcements.current;
+			if (currentAnnouncements.length > 0) {
+				if (!lastAnnouncement) {
+					// 初回のinitialize時
+					tl.set(announceRowA.current, {y: below});
+					tl.set(announceRowB.current, {y: above});
+					tl.call(() => {
+						setAnnounceA(currentAnnouncements[0])
+					});
+					tl.to(announceRowA.current, {y: 0, duration}, "<");
+				} else if (
+					lastAnnouncement.title === currentAnnouncements[0]?.title
+					&& lastAnnouncement.content === currentAnnouncements[0]?.content
+					&& !playOshiraseEnter
+				) {
+					// 直前の announcement を出し続ける場合
+					// announceRowB を出してる場合があるので announceRowA に入れ替える
+					tl.call(() => {
+						setAnnounceA(currentAnnouncements[0]);
+					});
+					tl.set(announceRowA.current, {y: 0});
+					tl.set(announceRowB.current, {y: above});
+				} else {
+					tl.to(announceRowA.current, {y: above, duration});
+					tl.to(announceRowB.current, {y: above, duration}, "<");
+					tl.set(announceRowA.current, {y: below});
+					tl.set(announceRowB.current, {y: above});
+					tl.call(() => {
+						setAnnounceA(currentAnnouncements[0])
+					});
+					tl.to(announceRowA.current, {y: 0, duration}, "<");
+				}
+				tl.to({}, {}, `+=${oshiraseHold}`);
+				for (let i = 1; i < currentAnnouncements.length; i++) {
+					const nextAnnouncement = currentAnnouncements[i];
+					tl.call(() => {
+						(i % 2 === 1 ? setAnnounceB : setAnnounceA)(nextAnnouncement);
+					});
+					const showing = (i % 2 === 1 ? announceRowB : announceRowA).current;
+					const hiding = (i % 2 === 1 ? announceRowA : announceRowB).current;
+					tl.to(hiding, {y: above, duration});
+					tl.set(showing, {y: below});
+					tl.to(showing, {y: 0, duration}, "<");
+					tl.to({}, {}, `+=${oshiraseHold}`);
+				}
 
-			if (playOshiraseEnter) {
-				tl.set(oshiraseRef.current, {y: below});
-				tl.set(donateLink.current, {y: 0});
-				tl.set(twitchIncome.current, {y: below});
-				tl.to(bidwarRef.current, {y: above});
-				tl.to(oshiraseRef.current, {y: 0}, "<");
-			} else {
-				tl.set(twitchIncome.current, {y: 0});
-				tl.set(donateLink.current, {y: below});
-				tl.to(twitchIncome.current, {y: above, duration});
-				tl.to(donateLink.current, {y: 0, duration}, "<");
+				[lastAnnouncement] = currentAnnouncements.slice(-1);
+			} else if (lastAnnouncement) {
+				tl.to(announceRowA.current, {y: above, duration});
+				tl.to(announceRowB.current, {y: above, duration}, "<");
+				lastAnnouncement = undefined;
 			}
-
-			tl.set(twitchIncome.current, {y: below});
-			tl.to(donateLink.current, {y: above, duration}, `+=${oshiraseHold}`);
-			tl.to(twitchIncome.current, {y: 0, duration}, "<");
-
-			tl.to({}, {}, `+=${oshiraseHold}`);
-
+			
 			tl.call(() => {
 				const currentBidwars = cloneDeep(bidwars.current).slice(
 					0,
@@ -517,7 +562,9 @@ const Omnibar = () => {
 					return;
 				}
 
-				tl.to(oshiraseRef.current, {y: above, duration});
+				tl.to(announceRowA.current, {y: above, duration});
+				tl.to(announceRowB.current, {y: above, duration}, "<");
+
 				if (currentBidwars && currentBidwars.length > 0) {
 					tl.call(() => {
 						setBidwarA(currentBidwars[0]);
@@ -597,6 +644,8 @@ const Omnibar = () => {
 			});
 		};
 
+		gsap.set(announceRowA.current, {y: below});
+		gsap.set(announceRowB.current, {y: below});
 		gsap.set(bidwarRef.current, {y: below});
 		gsap.set(bidChallengeRef.current, {y: below});
 		gsap.set(donationCommentRef.current, {y: below});
@@ -625,19 +674,21 @@ const Omnibar = () => {
 				backgroundColor: "rgb(230,230,230)",
 			}}
 		>
-			<Row header='RTA in Japanからのお知らせ' ref={oshiraseRef}>
+			<Row header={announceA?.title || ''} ref={announceRowA}>
 				<div style={{display: "grid"}}>
 					<ThinText
 						style={{fontSize: "24px", gridColumn: "1 / 2", gridRow: "1 / 2"}}
-						ref={donateLink}
 					>
-						国境なき医師団への寄付は donate.rtain.jp から
+						{ announceA?.content || ''}
 					</ThinText>
+				</div>
+			</Row>
+			<Row header={announceB?.title || ''} ref={announceRowB}>
+				<div style={{display: "grid"}}>
 					<ThinText
 						style={{fontSize: "24px", gridColumn: "1 / 2", gridRow: "1 / 2"}}
-						ref={twitchIncome}
 					>
-						イベント中のTwitchの収益も国境なき医師団に寄付されます
+						{ announceB?.content || ''}
 					</ThinText>
 				</div>
 			</Row>

--- a/src/browser/graphics/views/omnibar.tsx
+++ b/src/browser/graphics/views/omnibar.tsx
@@ -448,7 +448,7 @@ const Omnibar = () => {
 		}
 	}, [rawDonationQueue]);
 
-	const rawAnnouncements = useReplicant('announcements');
+	const rawAnnouncements = useReplicant("announcements");
 	const announcements = useRef<Announcements>([]);
 	useEffect(() => {
 		if (rawAnnouncements) {
@@ -486,7 +486,7 @@ const Omnibar = () => {
 
 		const initialize = (playOshiraseEnter: boolean) => {
 			tl = gsap.timeline();
-			
+
 			const currentAnnouncements = announcements.current;
 			if (currentAnnouncements.length > 0) {
 				if (!lastAnnouncement) {
@@ -494,13 +494,13 @@ const Omnibar = () => {
 					tl.set(announceRowA.current, {y: below});
 					tl.set(announceRowB.current, {y: above});
 					tl.call(() => {
-						setAnnounceA(currentAnnouncements[0])
+						setAnnounceA(currentAnnouncements[0]);
 					});
 					tl.to(announceRowA.current, {y: 0, duration}, "<");
 				} else if (
-					lastAnnouncement.title === currentAnnouncements[0]?.title
-					&& lastAnnouncement.content === currentAnnouncements[0]?.content
-					&& !playOshiraseEnter
+					lastAnnouncement.title === currentAnnouncements[0]?.title &&
+					lastAnnouncement.content === currentAnnouncements[0]?.content &&
+					!playOshiraseEnter
 				) {
 					// 直前の announcement を出し続ける場合
 					// announceRowB を出してる場合があるので announceRowA に入れ替える
@@ -515,7 +515,7 @@ const Omnibar = () => {
 					tl.set(announceRowA.current, {y: below});
 					tl.set(announceRowB.current, {y: above});
 					tl.call(() => {
-						setAnnounceA(currentAnnouncements[0])
+						setAnnounceA(currentAnnouncements[0]);
 					});
 					tl.to(announceRowA.current, {y: 0, duration}, "<");
 				}
@@ -539,7 +539,7 @@ const Omnibar = () => {
 				tl.to(announceRowB.current, {y: above, duration}, "<");
 				lastAnnouncement = undefined;
 			}
-			
+
 			tl.call(() => {
 				const currentBidwars = cloneDeep(bidwars.current).slice(
 					0,
@@ -674,21 +674,21 @@ const Omnibar = () => {
 				backgroundColor: "rgb(230,230,230)",
 			}}
 		>
-			<Row header={announceA?.title || ''} ref={announceRowA}>
+			<Row header={announceA?.title || ""} ref={announceRowA}>
 				<div style={{display: "grid"}}>
 					<ThinText
 						style={{fontSize: "24px", gridColumn: "1 / 2", gridRow: "1 / 2"}}
 					>
-						{ announceA?.content || ''}
+						{announceA?.content || ""}
 					</ThinText>
 				</div>
 			</Row>
-			<Row header={announceB?.title || ''} ref={announceRowB}>
+			<Row header={announceB?.title || ""} ref={announceRowB}>
 				<div style={{display: "grid"}}>
 					<ThinText
 						style={{fontSize: "24px", gridColumn: "1 / 2", gridRow: "1 / 2"}}
 					>
-						{ announceB?.content || ''}
+						{announceB?.content || ""}
 					</ThinText>
 				</div>
 			</Row>

--- a/src/nodecg/replicants.ts
+++ b/src/nodecg/replicants.ts
@@ -21,7 +21,7 @@ import {Runners} from "./generated/runners";
 import {Donations} from "./generated/donations";
 import {DonationQueue} from "./generated/donation-queue";
 import {VideoControl} from "./generated/video-control";
-import {Announcements} from './generated/announcements';
+import {Announcements} from "./generated/announcements";
 
 type Run = NonNullable<CurrentRun>;
 type Participant = Run["runners"][number];

--- a/src/nodecg/replicants.ts
+++ b/src/nodecg/replicants.ts
@@ -21,6 +21,7 @@ import {Runners} from "./generated/runners";
 import {Donations} from "./generated/donations";
 import {DonationQueue} from "./generated/donation-queue";
 import {VideoControl} from "./generated/video-control";
+import {Announcements} from './generated/announcements';
 
 type Run = NonNullable<CurrentRun>;
 type Participant = Run["runners"][number];
@@ -68,6 +69,7 @@ type ReplicantMap = {
 	"bid-challenge": BidChallenge;
 	"video-control": VideoControl;
 	"assets:interval-video": Assets[];
+	announcements: Announcements;
 };
 
 export {
@@ -94,4 +96,5 @@ export {
 	Donation,
 	DonationQueue,
 	BidChallenge,
+	Announcements,
 };


### PR DESCRIPTION
- resolve https://github.com/RTAinJapan/rtainjapan-layouts/issues/663

## dashboard

- dashboard からお知らせを追加・変更・削除できるようにした
- 0個にすることも可能

![ss_announcements_dashboard](https://user-images.githubusercontent.com/33190610/234264143-23de366e-0cae-4327-8ec3-530cc02f2bb5.gif)

## graphics

- Omnibar 上でお知らせをループ表示するようにした
- お知らせ0個の場合は何も表示しない
  - 寄付関連の情報がある場合は寄付関連のループになる

### bidsあり

![ss_omnibar_with_bids](https://user-images.githubusercontent.com/33190610/234264597-0a29c797-11a1-4db3-888c-42a58c99952f.gif)

### bidsなし

![ss_omnibar_without_bids](https://user-images.githubusercontent.com/33190610/234264650-2093c6bf-556c-435c-91ac-1da94749fd1e.gif)

### 対応しきれていないところ

- 表示しているブラウザを更新した際、初期化の順番次第で寄付関連の情報が先に表示される場合がある
- その際、何も表示されていないお知らせ欄が一瞬見える
- ブラウザの更新時だけ起きるため、重要ではなさそうなので対応してないです

![animation_bug](https://user-images.githubusercontent.com/33190610/234265673-bf3f6c51-7fb6-4411-a7e0-6ee0fc5def34.gif)
