### PR TITLE
feat(tracker): make websocket optional

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -18,7 +18,7 @@
 		"tracker": {
 			"type": "object",
 			"additionalProperties": false,
-			"required": ["domain", "event", "websocket", "secure"],
+			"required": ["domain", "event", "secure"],
 			"properties": {
 				"domain": {"type": "string"},
 				"event": {"type": "number"},

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -252,6 +252,13 @@ export const tracker = (nodecg: NodeCG) => {
 	}, 10 * 1000);
 
 	const connectWebSocket = () => {
+		if (!trackerConfig.websocket) {
+			log.warn(
+				"`websocket` config is empty. NodeCG will not connect to donation tracker's WebSocket.",
+			);
+			return;
+		}
+
 		const schema = trackerConfig.secure ? "wss" : "ws";
 		const url = new URL(
 			trackerConfig.websocket,


### PR DESCRIPTION
- 寄付の無いイベントではdonationのwebsocketに接続する必要が無い
- イベント期間外等でElasticCacheを止めてるとWebSocketのコネクションエラーが出続けるため、イベント期間外に開発する時に鬱陶しい
- tracker.websocketをoptionalにして、未設定の時は繋がないようにした