### PR TITLE
寄付有無を設定可能にした

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -103,6 +103,7 @@
 			"items": {
 				"type": "string"
 			}
-		}
+		},
+		"donationEnabled": {"type": "boolean", "default": true}
 	}
 }

--- a/src/browser/graphics/views/omnibar.tsx
+++ b/src/browser/graphics/views/omnibar.tsx
@@ -711,19 +711,23 @@ const Omnibar = () => {
 				</div>
 			</Row>
 
-			<img
-				src={lineImage}
-				style={{gridColumn: "3 / 4", gridRow: "1 / 2"}}
-			></img>
+			{nodecg.bundleConfig.donationEnabled && (
+				<>
+					<img
+						src={lineImage}
+						style={{gridColumn: "3 / 4", gridRow: "1 / 2"}}
+					></img>
 
-			<div style={{width: "15px"}}></div>
+					<div style={{width: "15px"}}></div>
 
-			<DonationTotal></DonationTotal>
+					<DonationTotal></DonationTotal>
 
-			<img
-				src={sponsorAssets?.[0]?.url}
-				style={{gridColumn: "5 / 6", gridRow: "1 / 2"}}
-			></img>
+					<img
+						src={sponsorAssets?.[0]?.url}
+						style={{gridColumn: "5 / 6", gridRow: "1 / 2"}}
+					></img>
+				</>
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
resolve #664 

# bundleConfig

`donationEnabled` で寄付有無を設定可能にした

# graphics

寄付無効の場合、合計額と寄付先スポンサー画像を表示しない

寄付額投票・寄付額チャレンジの表示制御はしていないが、 tracker 上に bids の設定がなければ表示されないので問題なし

![image](https://user-images.githubusercontent.com/33190610/234628392-82035cdc-829c-478a-a9df-8d0ffb891a52.png)
