### PR TITLE
ダッシュボードのカメラ情報入力フォームを改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 				"name": "camera",
 				"title": "カメラ",
 				"file": "camera.html",
-				"width": 2,
+				"width": 4,
 				"headerColor": "#00BEBE",
 				"workspace": "2-misc"
 			},

--- a/src/browser/dashboard/views/camera.tsx
+++ b/src/browser/dashboard/views/camera.tsx
@@ -1,42 +1,152 @@
 import "modern-normalize";
+import styled from "styled-components";
 import ReactDOM from "react-dom";
+import Button from "@material-ui/core/Button";
+import IconButton, {IconButtonProps} from "@material-ui/core/IconButton";
+import Typography from "@material-ui/core/Typography";
+import CheckIcon from "@material-ui/icons/Check";
+import EditIcon from "@material-ui/icons/Edit";
+import UndoIcon from "@material-ui/icons/Undo";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import {useEffect, useState} from "react";
+
 import {useReplicant} from "../../use-replicant";
 
-const cameraNameRep = nodecg.Replicant("camera-name");
+const Container = styled.div`
+	padding: 8px;
+`;
+
+type ButtonProps = Pick<IconButtonProps, "onClick">;
+
+const EditButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<EditIcon />
+		</IconButton>
+	);
+};
+
+const SubmitButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<CheckIcon />
+		</IconButton>
+	);
+};
+
+const UndoButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<UndoIcon />
+		</IconButton>
+	);
+};
 
 const App = () => {
+	const cameraNameRep = nodecg.Replicant("camera-name");
 	const cameraName = useReplicant("camera-name");
+	const [edit, setEdit] = useState<boolean>(false);
+	const [cameraNameForm, setCameraNameForm] = useState({
+		title: "",
+		name: "",
+	});
 	const cameraState = useReplicant("camera-state");
+	useEffect(() => {
+		setCameraNameForm({
+			title: cameraName?.title ?? "",
+			name: cameraName?.name ?? "",
+		});
+	}, [cameraName]);
 
 	return (
-		<div
-			style={{
-				padding: "8px",
-			}}
-		>
-			<label>名前</label>
-			<input
-				type='text'
-				value={cameraName?.name || ""}
-				onChange={(e) => {
-					if (cameraNameRep.value) {
-						cameraNameRep.value.name = e.target.value;
-					}
-				}}
-			/>
-			<button
+		<Container>
+			<List>
+				<ListItem>
+					<ListItemText
+						primary={
+							edit ? (
+								<input
+									value={cameraNameForm?.title}
+									onChange={(e) => {
+										setCameraNameForm({
+											...cameraNameForm,
+											title: e.currentTarget.value,
+										});
+									}}
+									placeholder='タイトル'
+								/>
+							) : (
+								`タイトル : ${cameraNameForm.title}`
+							)
+						}
+						secondary={
+							edit ? (
+								<input
+									value={cameraNameForm?.name}
+									onChange={(e) => {
+										setCameraNameForm({
+											...cameraNameForm,
+											name: e.currentTarget.value,
+										});
+									}}
+									placeholder='名前'
+								/>
+							) : (
+								<Typography variant='body2'>{`名前 : ${cameraNameForm.name}`}</Typography>
+							)
+						}
+					/>
+					<ListItemSecondaryAction>
+						{edit ? (
+							<>
+								<SubmitButton
+									onClick={() => {
+										if (cameraNameRep.value) {
+											cameraNameRep.value = {...cameraNameForm};
+										}
+										setEdit(false);
+									}}
+								/>
+								/
+								<UndoButton
+									onClick={() => {
+										setCameraNameForm({
+											title: cameraName?.title ?? "",
+											name: cameraName?.name ?? "",
+										});
+										setEdit(false);
+									}}
+								/>
+							</>
+						) : (
+							<>
+								<EditButton
+									onClick={() => {
+										setEdit(true);
+									}}
+								/>
+							</>
+						)}
+					</ListItemSecondaryAction>
+				</ListItem>
+			</List>
+			<Button
 				onClick={() => {
 					nodecg.sendMessage("toggleCameraName");
 				}}
 				disabled={cameraState === "big"}
+				variant='outlined'
 			>
 				{cameraState === "hidden"
 					? "表示する"
 					: cameraState === "big"
 					? "表示中(大)"
 					: "隠す"}
-			</button>
-		</div>
+			</Button>
+		</Container>
 	);
 };
 


### PR DESCRIPTION
resolve #665 

# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/665

# 概要
- カメラの名前入力フォームはonChangeイベントがReplicantと直結だったため日本語入力時に挙動が変になっていたので、お知らせ入力フォームと同様にボタンクリック時にReplicantに反映するように修正
- 同時にタイトル部分も入力可能とした

![image](https://user-images.githubusercontent.com/13300790/234908280-febb3418-70d3-4b2b-9f7a-bb8605b6cab3.png)
![image](https://user-images.githubusercontent.com/13300790/234908398-3bc8830f-5bae-4b97-abfc-80e36f000f82.png)

