### PR TITLE
fit-textは基本的に中央寄りにした

### DIFF
--- a/src/browser/graphics/components/game-info/horizontal.tsx
+++ b/src/browser/graphics/components/game-info/horizontal.tsx
@@ -31,7 +31,11 @@ export const HorizontalGameInfo = (props: {style?: CSSProperties}) => {
 					justifyItems: "start",
 				}}
 			>
-				<FitText defaultSize={22} thin={true}>
+				<FitText
+					defaultSize={22}
+					thin={true}
+					style={{textAlign: "left", display: "block"}}
+				>
 					{currentRun?.category}
 				</FitText>
 				<div>

--- a/src/browser/graphics/components/lib/fit-text.tsx
+++ b/src/browser/graphics/components/lib/fit-text.tsx
@@ -43,6 +43,7 @@ export const FitText: FunctionComponent<{
 				fontSize: `${size}px`,
 				display: "grid",
 				placeItems: "center",
+				textAlign: "center",
 				...props.style,
 			}}
 		>


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/655
-  https://github.com/RTAinJapan/rtainjapan-layouts/pull/668 で対応したやつの不足分を対応

# 概要
- FitTextで改行した時、左寄りになってしまう事象への対応
- 原則中央寄りにし、左寄りにしたい時はStyleを指定してもらう対応にした
  - もっとキレイな方法ががあるけど暫定で。
 
- horizontal
- <img width="1317" alt="image" src="https://user-images.githubusercontent.com/3125070/235078457-e4c3ed3d-b69b-4f9f-8eec-c544b045f346.png">
- <img width="1214" alt="image" src="https://user-images.githubusercontent.com/3125070/235078941-d175c5ea-3b18-4442-a394-a76c26015a9a.png">


- semi-horizontal
- これの時はカテゴリを改行しない方がよさげ。
- <img width="816" alt="image" src="https://user-images.githubusercontent.com/3125070/235078535-4a7c9dc8-c1b0-4d6f-a489-bdc8cfa855ea.png">
- <img width="820" alt="image" src="https://user-images.githubusercontent.com/3125070/235079031-6104ee69-55b4-4c24-80d0-505dc3e576af.png">


- vertical
- これの時はカテゴリを改行しない方がよさげ。
- <img width="663" alt="image" src="https://user-images.githubusercontent.com/3125070/235078688-1a9405f8-ad52-4d79-9085-fcf7f1ccfee1.png">
- <img width="559" alt="image" src="https://user-images.githubusercontent.com/3125070/235079105-7d0a32b5-8f7a-4602-9842-e1c8384aa3de.png">

- credit
- たぶん中央揃えのまま変わらないはず
- <img width="1119" alt="image" src="https://user-images.githubusercontent.com/3125070/235079329-664a2fd3-73cd-4251-93f1-1355f75b3366.png">
