### PR TITLE
FitTextのフォントサイズ調整を縦幅でも行うよう修正

### DIFF
--- a/src/browser/graphics/components/lib/fit-text.tsx
+++ b/src/browser/graphics/components/lib/fit-text.tsx
@@ -20,13 +20,23 @@ export const FitText: FunctionComponent<{
 
 	useEffect(() => {
 		setSize(props.defaultSize);
+
+		const fixSize = (max: number | undefined, current: number | undefined) => {
+			if (max && current && max < current) {
+				setSize((size) => size * (max / current));
+			}
+		};
+
 		const fit = () => {
 			const maxWidth = ref?.current?.clientWidth;
 			const currentWidth = ref?.current?.scrollWidth;
-			if (maxWidth && currentWidth && maxWidth < currentWidth) {
-				setSize((size) => size * (maxWidth / currentWidth));
-			}
+			fixSize(maxWidth, currentWidth);
+
+			const maxHeight = ref?.current?.clientHeight;
+			const currentHeight = ref?.current?.scrollHeight;
+			fixSize(maxHeight, currentHeight);
 		};
+
 		const interval = setInterval(fit, 100);
 		fit();
 		return () => {
@@ -39,6 +49,7 @@ export const FitText: FunctionComponent<{
 			ref={ref}
 			style={{
 				width: "100%",
+				height: "100%",
 				overflow: "hidden",
 				fontSize: `${size}px`,
 				display: "grid",


### PR DESCRIPTION
resolve #684 

# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/684

# 概要
- FitTextで改行した際に縦幅が親要素をはみ出てしまう場合があるので縦幅に合わせたフォントサイズ調整を追加
![image](https://user-images.githubusercontent.com/13300790/235135482-f2602382-293d-40cc-a3ea-878b77669612.png)

- 改行なし
![image](https://user-images.githubusercontent.com/3125070/235211286-7c5c322e-11b6-4dd5-8812-a34841065c5d.png)
![image](https://user-images.githubusercontent.com/3125070/235211894-e23635b6-2581-4e80-a16a-97b374057da6.png)

- 非常に短いワードでの改行
![image](https://user-images.githubusercontent.com/3125070/235211408-26bee709-6dd9-4712-ac09-3beb3fdb130d.png)

- 改行前後で極端に文字数に差がある時
![image](https://user-images.githubusercontent.com/3125070/235211603-d6049adf-6975-44f0-9ece-a2f0a1d596fa.png)
