### PR TITLE
CameraレイアウトのBigNameplateに肩書を追加

### DIFF
--- a/src/browser/graphics/views/camera.tsx
+++ b/src/browser/graphics/views/camera.tsx
@@ -39,6 +39,18 @@ const BigNameplate = (props: {innerRef?: RefObject<HTMLDivElement>}) => {
 			<BoldText
 				style={{
 					gridColumn: "2 / 3",
+					gridRow: "2 / 3",
+					alignSelf: "center",
+					justifySelf: "start",
+					fontSize: "24px",
+					textShadow: "0 0 10px black",
+				}}
+			>
+				{camera?.title}
+			</BoldText>
+			<BoldText
+				style={{
+					gridColumn: "2 / 3",
 					gridRow: "3 / 4",
 					alignSelf: "center",
 					justifySelf: "start",


### PR DESCRIPTION
# Issue
- https://github.com/RTAinJapan/rtainjapan-layouts/issues/681

# 概要
- 一時表示用のBigNameplateに肩書を追加

- 肩書なし
<img width="632" alt="image" src="https://user-images.githubusercontent.com/3125070/235228116-a818c760-8267-4dbd-8509-d6094f37be00.png">

- 肩書あり
<img width="632" alt="image" src="https://user-images.githubusercontent.com/3125070/235228177-fc77245c-e77b-4db9-8e5c-759919bfb25d.png">

- 肩書あり（長い）

<img width="971" alt="image" src="https://user-images.githubusercontent.com/3125070/235228805-5d2ea664-0c8f-4b5f-8043-d8b0dc9df470.png">
