### PR TITLE
タイマー開始後は次のゲームのチェックリストを表示する

### DIFF
--- a/schemas/checklist.json
+++ b/schemas/checklist.json
@@ -6,10 +6,11 @@
 		"type": "object",
 		"additionalProperties": false,
 		"properties": {
+			"pk": {"type": "string"},
 			"name": {"type": "string"},
 			"complete": {"type": "boolean"}
 		},
-		"required": ["name", "complete"]
+		"required": ["pk", "name", "complete"]
 	},
 	"default": []
 }

--- a/schemas/checklist.json
+++ b/schemas/checklist.json
@@ -7,10 +7,9 @@
 		"additionalProperties": false,
 		"properties": {
 			"pk": {"type": "string"},
-			"name": {"type": "string"},
-			"complete": {"type": "boolean"}
+			"name": {"type": "string"}
 		},
-		"required": ["pk", "name", "complete"]
+		"required": ["pk", "name"]
 	},
 	"default": []
 }

--- a/schemas/lib/run.json
+++ b/schemas/lib/run.json
@@ -30,7 +30,8 @@
 		},
 		"completedChecklist": {
 			"type": "array",
-			"items": {"type": "string"}
+			"items": {"type": "string"},
+			"description": "完了したチェックリストのPKの配列"
 		}
 	},
 	"required": [

--- a/schemas/lib/run.json
+++ b/schemas/lib/run.json
@@ -28,9 +28,9 @@
 		"twitchGameId": {
 			"type": "string"
 		},
-		"checklistStatus": {
-			"type": "object",
-			"additionalProperties": {"type": "boolean"}
+		"completedChecklist": {
+			"type": "array",
+			"items": {"type": "string"}
 		}
 	},
 	"required": [
@@ -42,6 +42,6 @@
 		"setupDuration",
 		"runners",
 		"commentators",
-		"checklistStatus"
+		"completedChecklist"
 	]
 }

--- a/schemas/lib/run.json
+++ b/schemas/lib/run.json
@@ -27,6 +27,10 @@
 		},
 		"twitchGameId": {
 			"type": "string"
+		},
+		"checklistStatus": {
+			"type": "object",
+			"additionalProperties": {"type": "boolean"}
 		}
 	},
 	"required": [
@@ -37,6 +41,7 @@
 		"runDuration",
 		"setupDuration",
 		"runners",
-		"commentators"
+		"commentators",
+		"checklistStatus"
 	]
 }

--- a/src/browser/dashboard/components/checklist/Checkbox.tsx
+++ b/src/browser/dashboard/components/checklist/Checkbox.tsx
@@ -1,0 +1,24 @@
+import {Checklist} from "../../../../nodecg/replicants";
+import MuiCheckbox from "@material-ui/core/Checkbox";
+
+type Props = {
+	checklist: Checklist[number];
+	runPk: number;
+	complete: boolean;
+};
+
+export const Checkbox = ({checklist, runPk, complete}: Props) => {
+	return (
+		<MuiCheckbox
+			name={checklist.name}
+			checked={complete}
+			onChange={(_, checked) => {
+				nodecg.sendMessage("toggleCheckbox", {
+					runPk,
+					checkPk: checklist.pk,
+					checked,
+				});
+			}}
+		/>
+	);
+};

--- a/src/browser/dashboard/components/checklist/index.tsx
+++ b/src/browser/dashboard/components/checklist/index.tsx
@@ -100,7 +100,7 @@ export class Checklist extends React.Component {
 		checklist: ChecklistType[0],
 		run: Run,
 	) => {
-		const complete = run.checklistStatus[checklist.pk] ?? false;
+		const complete = run.completedChecklist.includes(checklist.pk);
 
 		return (
 			<FormControlLabel

--- a/src/browser/dashboard/components/checklist/index.tsx
+++ b/src/browser/dashboard/components/checklist/index.tsx
@@ -1,11 +1,19 @@
-import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import React, {ChangeEvent} from "react";
+import React from "react";
 import styled from "styled-components";
-import {Checklist as ChecklistType, Timer} from "../../../../nodecg/replicants";
+import {Run} from "../../../../nodecg/generated";
+import {
+	Checklist as ChecklistType,
+	CurrentRun,
+	NextRun,
+	Timer,
+} from "../../../../nodecg/replicants";
 import {BorderedBox} from "../lib/bordered-box";
+import {Checkbox} from "./Checkbox";
 
 const checklistRep = nodecg.Replicant("checklist");
+const currentRunRep = nodecg.Replicant("current-run");
+const nextRunRep = nodecg.Replicant("next-run");
 const timerRep = nodecg.Replicant("timer");
 
 const Container = styled(BorderedBox)`
@@ -17,34 +25,60 @@ const Container = styled(BorderedBox)`
 	user-select: none;
 `;
 
+const CurrentRunNameRow = styled.div`
+	text-align: center;
+	grid-column: 1 / 3;
+`;
+
 interface State {
 	checklist: ChecklistType;
-	disable: boolean;
+	currentRun: CurrentRun;
+	nextRun: NextRun;
+	setupNext: boolean;
 }
 
 export class Checklist extends React.Component {
-	public state: State = {checklist: [], disable: false};
+	public state: State = {
+		checklist: [],
+		currentRun: null,
+		nextRun: null,
+		setupNext: false,
+	};
 
 	public componentDidMount() {
 		checklistRep.on("change", this.checklistChangeHandler);
+		currentRunRep.on("change", this.currentRunChangeHandler);
+		nextRunRep.on("change", this.nextRunChangeHandler);
 		timerRep.on("change", this.#timerChangeHandler);
 	}
 
 	public componentWillUnmount() {
 		checklistRep.removeListener("change", this.checklistChangeHandler);
+		currentRunRep.removeListener("change", this.currentRunChangeHandler);
+		nextRunRep.removeListener("change", this.nextRunChangeHandler);
 		timerRep.removeListener("change", this.#timerChangeHandler);
 	}
 
 	#timerChangeHandler = (newVal: Timer) => {
-		const disable = newVal.timerState === "Running";
-		this.setState({disable});
+		const setupNext = ["Running", "Finished"].includes(newVal.timerState);
+		this.setState({setupNext});
 	};
 
 	public render() {
+		const targetRun =
+			this.state.setupNext && this.state.nextRun
+				? this.state.nextRun
+				: this.state.currentRun;
+
 		return (
 			<Container>
-				{this.state.checklist.map((checklist) =>
-					this.makeChecklistElement(checklist),
+				<CurrentRunNameRow>
+					{this.state.setupNext ? "次のゲーム" : "現在のゲーム"} -{" "}
+					{targetRun?.title}
+				</CurrentRunNameRow>
+				{this.state.checklist.map(
+					(checklist) =>
+						targetRun && this.makeChecklistElement(checklist, targetRun),
 				)}
 			</Container>
 		);
@@ -54,25 +88,33 @@ export class Checklist extends React.Component {
 		this.setState({checklist: newVal});
 	};
 
-	private readonly toggleCheckbox = (e: ChangeEvent<any>, checked: boolean) => {
-		nodecg.sendMessage("toggleCheckbox", {
-			name: e.target.name,
-			checked,
-		});
+	private readonly currentRunChangeHandler = (newVal: CurrentRun) => {
+		this.setState({currentRun: newVal});
 	};
 
-	private readonly makeChecklistElement = (checklist: ChecklistType[0]) => (
-		<FormControlLabel
-			disabled={this.state.disable}
-			key={checklist.name}
-			control={<Checkbox checked={checklist.complete} name={checklist.name} />}
-			label={checklist.name}
-			onChange={this.toggleCheckbox}
-			style={{
-				margin: "0",
-				borderRadius: "3px",
-				border: "1px solid black",
-			}}
-		/>
-	);
+	private readonly nextRunChangeHandler = (newVal: NextRun) => {
+		this.setState({nextRun: newVal});
+	};
+
+	private readonly makeChecklistElement = (
+		checklist: ChecklistType[0],
+		run: Run,
+	) => {
+		const complete = run.checklistStatus[checklist.pk] ?? false;
+
+		return (
+			<FormControlLabel
+				key={checklist.name}
+				control={
+					<Checkbox runPk={run.pk} checklist={checklist} complete={complete} />
+				}
+				label={checklist.name}
+				style={{
+					margin: "0",
+					borderRadius: "3px",
+					border: "1px solid black",
+				}}
+			/>
+		);
+	};
 }

--- a/src/browser/dashboard/components/timekeeper/index.tsx
+++ b/src/browser/dashboard/components/timekeeper/index.tsx
@@ -74,6 +74,7 @@ interface State {
 	checklistComplete: boolean;
 	isModalOpened: boolean;
 	checklistPks: string[];
+	completedChecklist: string[];
 }
 
 export class Timekeeper extends React.Component<{}, State> {
@@ -83,6 +84,7 @@ export class Timekeeper extends React.Component<{}, State> {
 		checklistComplete: false,
 		isModalOpened: false,
 		checklistPks: [],
+		completedChecklist: [],
 	};
 
 	public render() {
@@ -194,27 +196,39 @@ export class Timekeeper extends React.Component<{}, State> {
 			return;
 		}
 		const newRunners = newVal.runners;
-		const checklistComplete = this.state.checklistPks
-			.map((pk) => newVal.checklistStatus[pk])
-			.every((completed) => completed);
 		this.setState({
 			runners: Array.from({length: 4}, (_, index) => {
 				const name = newRunners && newRunners[index] && newRunners[index]?.name;
 				return {name, id: uuidv4()};
 			}),
-			checklistComplete,
+			completedChecklist: Object.entries(newVal.checklistStatus)
+				.filter(([_, completed]) => {
+					return completed;
+				})
+				.map(([pk]) => pk),
 		});
+		this.updateChecklistComplete();
 	};
 
 	private readonly checklistChangeHandler = (newVal: Checklist) => {
 		this.setState({
 			checklistPks: newVal.map((check) => check.pk),
 		});
+		this.updateChecklistComplete();
 	};
 
 	private readonly stopwatchRepChangeHandler = (newVal: Timer) => {
 		this.setState({
 			timer: newVal,
+		});
+	};
+
+	private readonly updateChecklistComplete = () => {
+		const checklistComplete = this.state.checklistPks.every((pk) =>
+			this.state.completedChecklist.includes(pk),
+		);
+		this.setState({
+			checklistComplete,
 		});
 	};
 }

--- a/src/browser/dashboard/components/timekeeper/index.tsx
+++ b/src/browser/dashboard/components/timekeeper/index.tsx
@@ -201,11 +201,7 @@ export class Timekeeper extends React.Component<{}, State> {
 				const name = newRunners && newRunners[index] && newRunners[index]?.name;
 				return {name, id: uuidv4()};
 			}),
-			completedChecklist: Object.entries(newVal.checklistStatus)
-				.filter(([_, completed]) => {
-					return completed;
-				})
-				.map(([pk]) => pk),
+			completedChecklist: newVal.completedChecklist,
 		});
 		this.updateChecklistComplete();
 	};

--- a/src/browser/dashboard/components/timekeeper/index.tsx
+++ b/src/browser/dashboard/components/timekeeper/index.tsx
@@ -73,6 +73,7 @@ interface State {
 	runners: Array<{name: string | undefined; id: string}>;
 	checklistComplete: boolean;
 	isModalOpened: boolean;
+	checklistPks: string[];
 }
 
 export class Timekeeper extends React.Component<{}, State> {
@@ -81,6 +82,7 @@ export class Timekeeper extends React.Component<{}, State> {
 		runners: [],
 		checklistComplete: false,
 		isModalOpened: false,
+		checklistPks: [],
 	};
 
 	public render() {
@@ -192,17 +194,21 @@ export class Timekeeper extends React.Component<{}, State> {
 			return;
 		}
 		const newRunners = newVal.runners;
+		const checklistComplete = this.state.checklistPks
+			.map((pk) => newVal.checklistStatus[pk])
+			.every((completed) => completed);
 		this.setState({
 			runners: Array.from({length: 4}, (_, index) => {
 				const name = newRunners && newRunners[index] && newRunners[index]?.name;
 				return {name, id: uuidv4()};
 			}),
+			checklistComplete,
 		});
 	};
 
 	private readonly checklistChangeHandler = (newVal: Checklist) => {
 		this.setState({
-			checklistComplete: newVal.every((item) => item.complete),
+			checklistPks: newVal.map((check) => check.pk),
 		});
 	};
 

--- a/src/extension/checklist.ts
+++ b/src/extension/checklist.ts
@@ -42,15 +42,38 @@ export const checklist = (nodecg: NodeCG) => {
 		const scheduleRun = scheduleRep.value.find(
 			(run) => run.pk === payload.runPk,
 		);
-		if (scheduleRun) {
-			scheduleRun.checklistStatus[payload.checkPk] = payload.checked;
-		}
 
-		if (currentRunRep.value?.pk === payload.runPk) {
-			currentRunRep.value.checklistStatus[payload.checkPk] = payload.checked;
-		}
-		if (nextRunRep.value?.pk === payload.runPk) {
-			nextRunRep.value.checklistStatus[payload.checkPk] = payload.checked;
+		if (payload.checked) {
+			scheduleRun &&
+				(scheduleRun.completedChecklist = [
+					...scheduleRun.completedChecklist,
+					payload.checkPk,
+				]);
+			currentRunRep.value?.pk === payload.runPk &&
+				(currentRunRep.value.completedChecklist = [
+					...currentRunRep.value.completedChecklist,
+					payload.checkPk,
+				]);
+			nextRunRep.value?.pk === payload.runPk &&
+				(nextRunRep.value.completedChecklist = [
+					...nextRunRep.value.completedChecklist,
+					payload.checkPk,
+				]);
+		} else {
+			scheduleRun &&
+				(scheduleRun.completedChecklist = scheduleRun.completedChecklist.filter(
+					(pk) => pk !== payload.checkPk,
+				));
+			currentRunRep.value?.pk === payload.runPk &&
+				(currentRunRep.value.completedChecklist =
+					currentRunRep.value.completedChecklist.filter(
+						(pk) => pk !== payload.checkPk,
+					));
+			nextRunRep.value?.pk === payload.runPk &&
+				(nextRunRep.value.completedChecklist =
+					nextRunRep.value.completedChecklist.filter(
+						(pk) => pk !== payload.checkPk,
+					));
 		}
 	};
 

--- a/src/extension/checklist.ts
+++ b/src/extension/checklist.ts
@@ -1,5 +1,6 @@
-import {isEqual} from "lodash";
+import {clone} from "lodash";
 import {NodeCG} from "./nodecg";
+import {v4 as uuid} from "uuid";
 
 export const checklist = (nodecg: NodeCG) => {
 	const log = new nodecg.Logger("tracker");
@@ -11,27 +12,21 @@ export const checklist = (nodecg: NodeCG) => {
 		return;
 	}
 
-	const defaultChecklist = [...new Set(checklist)].map((item) => ({
-		name: item,
-		complete: false,
-	}));
+	const configChecklistNames = [...new Set(checklist)];
 
-	if (checklistRep.value && checklistRep.value.length > 0) {
-		const currentNameList = checklistRep.value.map((item) => item.name);
-		const defaultNameList = defaultChecklist;
-		if (!isEqual(currentNameList, defaultNameList)) {
-			if (checklistRep.value.every((item) => item.complete)) {
-				checklistRep.value = checklist.map((item) => ({
-					name: item,
-					complete: true,
-				}));
-			} else {
-				checklistRep.value = defaultChecklist;
+	const currentChecklist = checklistRep.value ? clone(checklistRep.value) : [];
+
+	checklistRep.value = configChecklistNames.map((name) => {
+		const existsCurrent = currentChecklist.find((c) => c.name === name);
+
+		return (
+			existsCurrent ?? {
+				pk: uuid(),
+				name,
+				complete: false,
 			}
-		}
-	} else {
-		checklistRep.value = defaultChecklist;
-	}
+		);
+	});
 
 	const toggleCheckbox = (payload: {name: string; checked: boolean}) => {
 		if (!checklistRep.value) {

--- a/src/extension/checklist.ts
+++ b/src/extension/checklist.ts
@@ -1,6 +1,7 @@
 import {clone} from "lodash";
 import {NodeCG} from "./nodecg";
 import {v4 as uuid} from "uuid";
+import {Run} from "../nodecg/generated";
 
 export const checklist = (nodecg: NodeCG) => {
 	const log = new nodecg.Logger("tracker");
@@ -30,6 +31,16 @@ export const checklist = (nodecg: NodeCG) => {
 		);
 	});
 
+	const complete = (run: Run, checklistPk: string) => {
+		run.completedChecklist = [...run.completedChecklist, checklistPk];
+	};
+
+	const uncomplete = (run: Run, checklistPk: string) => {
+		run.completedChecklist = run.completedChecklist.filter(
+			(pk) => pk !== checklistPk,
+		);
+	};
+
 	const toggleCheckbox = (payload: {
 		runPk: number;
 		checkPk: string;
@@ -44,36 +55,17 @@ export const checklist = (nodecg: NodeCG) => {
 		);
 
 		if (payload.checked) {
-			scheduleRun &&
-				(scheduleRun.completedChecklist = [
-					...scheduleRun.completedChecklist,
-					payload.checkPk,
-				]);
+			scheduleRun && complete(scheduleRun, payload.checkPk);
 			currentRunRep.value?.pk === payload.runPk &&
-				(currentRunRep.value.completedChecklist = [
-					...currentRunRep.value.completedChecklist,
-					payload.checkPk,
-				]);
+				complete(currentRunRep.value, payload.checkPk);
 			nextRunRep.value?.pk === payload.runPk &&
-				(nextRunRep.value.completedChecklist = [
-					...nextRunRep.value.completedChecklist,
-					payload.checkPk,
-				]);
+				complete(nextRunRep.value, payload.checkPk);
 		} else {
-			scheduleRun &&
-				(scheduleRun.completedChecklist = scheduleRun.completedChecklist.filter(
-					(pk) => pk !== payload.checkPk,
-				));
+			scheduleRun && uncomplete(scheduleRun, payload.checkPk);
 			currentRunRep.value?.pk === payload.runPk &&
-				(currentRunRep.value.completedChecklist =
-					currentRunRep.value.completedChecklist.filter(
-						(pk) => pk !== payload.checkPk,
-					));
+				uncomplete(currentRunRep.value, payload.checkPk);
 			nextRunRep.value?.pk === payload.runPk &&
-				(nextRunRep.value.completedChecklist =
-					nextRunRep.value.completedChecklist.filter(
-						(pk) => pk !== payload.checkPk,
-					));
+				uncomplete(nextRunRep.value, payload.checkPk);
 		}
 	};
 

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -5,17 +5,7 @@ export default async (nodecg: NodeCG) => {
 	const scheduleRep = nodecg.Replicant("schedule");
 	const currentRunRep = nodecg.Replicant("current-run");
 	const nextRunRep = nodecg.Replicant("next-run");
-	const checklistRep = nodecg.Replicant("checklist");
 	const timerRep = nodecg.Replicant("timer");
-
-	const resetChecklist = () => {
-		if (checklistRep.value) {
-			checklistRep.value = checklistRep.value.map((item) => ({
-				...item,
-				complete: false,
-			}));
-		}
-	};
 
 	const updateCurrentRun = (index: number) => {
 		if (timerRep.value?.timerState === "Running") {
@@ -24,7 +14,6 @@ export default async (nodecg: NodeCG) => {
 		if (!scheduleRep.value) {
 			return;
 		}
-		resetChecklist();
 		const newCurrentRun = scheduleRep.value[index];
 		if (!newCurrentRun) {
 			return;
@@ -48,7 +37,6 @@ export default async (nodecg: NodeCG) => {
 		if (currentIndex >= scheduleRep.value.length - 1) {
 			return;
 		}
-		resetChecklist();
 		currentRunRep.value = cloneDeep(nextRunRep.value);
 		nextRunRep.value = cloneDeep(scheduleRep.value[currentIndex + 2]);
 	};
@@ -68,7 +56,6 @@ export default async (nodecg: NodeCG) => {
 		if (currentIndex === 0) {
 			return;
 		}
-		resetChecklist();
 		nextRunRep.value = cloneDeep(currentRunRep.value);
 		currentRunRep.value = cloneDeep(scheduleRep.value[currentIndex - 1]);
 	};

--- a/src/extension/timekeeping.ts
+++ b/src/extension/timekeeping.ts
@@ -50,7 +50,9 @@ export const timekeeping = (nodecg: NodeCG) => {
 		// Don't start if checklist is not completed
 		if (
 			!checklistRep.value ||
-			checklistRep.value.some((item) => !item.complete)
+			checklistRep.value.some(
+				(item) => !currentRunRep.value?.checklistStatus[item.pk],
+			)
 		) {
 			return;
 		}

--- a/src/extension/timekeeping.ts
+++ b/src/extension/timekeeping.ts
@@ -51,7 +51,7 @@ export const timekeeping = (nodecg: NodeCG) => {
 		if (
 			!checklistRep.value ||
 			checklistRep.value.some(
-				(item) => !currentRunRep.value?.checklistStatus[item.pk],
+				(item) => !currentRunRep.value?.completedChecklist.includes(item.pk),
 			)
 		) {
 			return;

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -108,7 +108,7 @@ export const tracker = (nodecg: NodeCG) => {
 				})
 				.map<Run>((run, index) => {
 					const prevCompletedChecklist =
-						prevSchedule.find((pRun) => pRun.pk === run.pk)
+						prevSchedule.find((prevRun) => prevRun.pk === run.pk)
 							?.completedChecklist ?? [];
 					return {
 						pk: run.pk,

--- a/src/extension/tracker.ts
+++ b/src/extension/tracker.ts
@@ -107,9 +107,9 @@ export const tracker = (nodecg: NodeCG) => {
 					return run.fields.order !== null;
 				})
 				.map<Run>((run, index) => {
-					const prevCheckStatus = prevSchedule.find(
-						(pRun) => pRun.pk === run.pk,
-					)?.checklistStatus;
+					const prevCompletedChecklist =
+						prevSchedule.find((pRun) => pRun.pk === run.pk)
+							?.completedChecklist ?? [];
 					return {
 						pk: run.pk,
 						index,
@@ -145,12 +145,12 @@ export const tracker = (nodecg: NodeCG) => {
 								};
 							}),
 						twitchGameId: run.fields.twitch_name,
-						checklistStatus: Object.fromEntries(
-							checklistRep.value?.map(({pk}) => {
-								const completed = prevCheckStatus?.[pk] ?? false;
-								return [pk, completed];
-							}) ?? [],
-						),
+						completedChecklist:
+							checklistRep.value
+								?.filter((checklist) => {
+									return prevCompletedChecklist.includes(checklist.pk);
+								})
+								.map((checklist) => checklist.pk) ?? [],
 					};
 				});
 			runnersRep.value = runners.map((runner) => runner.fields.name);

--- a/src/nodecg/messages.ts
+++ b/src/nodecg/messages.ts
@@ -26,7 +26,7 @@ export type MessageMap = {
 	nextRun: {};
 	previousRun: {};
 	modifyRun: {data: Run; error: string};
-	toggleCheckbox: {data: {name: string; checked: boolean}};
+	toggleCheckbox: {data: {runPk: number; checkPk: string; checked: boolean}};
 	resetChecklist: {};
 	"obs:connect": {};
 	"obs:disconnect": {};


### PR DESCRIPTION
resolve #683 

dashboard 上、タイマーが開始した後は次のゲームのチェックリストを表示するように変更した。

## 開始前

![image](https://user-images.githubusercontent.com/33190610/235297284-f98a8ffd-820c-468e-8c94-0811157e0afd.png)

## チェックリストを埋めた

![image](https://user-images.githubusercontent.com/33190610/235297300-a9d10890-d1e1-4f1c-ab56-00146042ee3e.png)

## タイマー開始

![image](https://user-images.githubusercontent.com/33190610/235297313-e62e0345-4474-435a-b5b6-80887d7e3916.png)

## 一時停止した

- 一時停止中は現在のゲームのチェックリストを表示
  - 何か問題が起きた時にチェックリスト再利用したいとか、あるかも

![image](https://user-images.githubusercontent.com/33190610/235297358-d4f7cdf7-23d8-4a37-84ab-219ebc6b1c91.png)

## 完走・リタイア

- 次のゲームのチェックリストを表示

![image](https://user-images.githubusercontent.com/33190610/235297391-23d2694a-d6f9-426e-a0f0-b926c36a5836.png)

# 細かいところ

- `schedule` replicants にチェックリストの状態を保持しています
- tracker からスケジュールを取ってくるときは、 `run.pk` を参照してチェックリストの状態を保存する
- `run.pk` は tracker 内で一意なので、イベントが変わってスケジュールが一新したらチェックリストの状態はまっさらになる