### PR TITLE
再生中の曲名を API 経由で更新できるようにする

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -63,7 +63,13 @@
 			"required": ["clientId", "clientSecret"],
 			"properties": {
 				"clientId": {"type": "string"},
-				"clientSecret": {"type": "string"},
+				"clientSecret": {"type": "string"}
+			}
+		},
+		"music": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
 				"textPrefix": {"type": "string", "default": ""},
 				"textSuffix": {"type": "string", "default": ""}
 			}

--- a/schemas/playing-music.json
+++ b/schemas/playing-music.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "string"
+}

--- a/src/browser/graphics/components/music.tsx
+++ b/src/browser/graphics/components/music.tsx
@@ -6,9 +6,10 @@ import {setup} from "../styles/colors";
 import {ThinText} from "./lib/text";
 
 export const Music = () => {
-	const spotify = useReplicant("spotify");
-	// prettier-ignore
-	const text = `${nodecg.bundleConfig.spotify?.textPrefix ?? ""} ${spotify?.currentTrack?.name} - ${spotify?.currentTrack?.artists} ${nodecg.bundleConfig.spotify?.textSuffix ?? ""}`;
+	const playingMusic = useReplicant("playing-music");
+	const text = `${
+		nodecg.bundleConfig.music?.textPrefix ?? ""
+	} ${playingMusic} ${nodecg.bundleConfig.music?.textSuffix ?? ""}`;
 	const ref = useRef<HTMLDivElement>(null);
 	const [shownText, setShownText] = useState("");
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,16 +1,16 @@
 import {checklist} from "./checklist";
 import schedule from "./schedule";
-import {spotify} from "./spotify";
 import {timekeeping} from "./timekeeping";
 import {NodeCG} from "./nodecg";
 import {twitch} from "./twitch";
 import {setupObs} from "./obs";
 import {tracker} from "./tracker";
+import {music} from "./music";
 
 export default (nodecg: NodeCG) => {
 	checklist(nodecg);
 	schedule(nodecg);
-	spotify(nodecg);
+	music(nodecg);
 	timekeeping(nodecg);
 	twitch(nodecg);
 	setupObs(nodecg);

--- a/src/extension/music.ts
+++ b/src/extension/music.ts
@@ -1,0 +1,41 @@
+import {PlayingMusic} from "../nodecg/replicants";
+import {NodeCG} from "./nodecg";
+import express from "express";
+
+type UpdateMusicRequest = {
+	id: string;
+	data: PlayingMusic;
+};
+
+export const music = (nodecg: NodeCG) => {
+	const basePath = "/playing-music";
+	const log = new nodecg.Logger("music");
+
+	const playingMusicRep = nodecg.Replicant("playing-music", {defaultValue: ""});
+
+	const updatePlayingMusic = (music: PlayingMusic) => {
+		playingMusicRep.value = music;
+		log.debug(`Update playing music to "${music}"`);
+	};
+
+	const router = express();
+	router.put<never, string, UpdateMusicRequest>("/", (req, res) => {
+		try {
+			const playingMusic = req.body.data;
+			updatePlayingMusic(playingMusic);
+
+			res.status(204).send();
+		} catch (err: unknown) {
+			log.error("Unknown error is happened on update playing music", err);
+			res.status(500).send();
+		}
+	});
+
+	nodecg.mount(basePath, router);
+	log.warn(
+		`Mounted update playing-music API to: ${new URL(
+			basePath,
+			`${nodecg.config.ssl ? "https" : "http"}://${nodecg.config.baseURL}`,
+		)}`,
+	);
+};

--- a/src/nodecg/replicants.d.ts
+++ b/src/nodecg/replicants.d.ts
@@ -22,6 +22,7 @@ import {Donations} from "./generated/donations";
 import {DonationQueue} from "./generated/donation-queue";
 import {VideoControl} from "./generated/video-control";
 import {Announcements} from "./generated/announcements";
+import {PlayingMusic} from "./generated/playing-music";
 
 type Run = NonNullable<CurrentRun>;
 type Participant = Run["runners"][number];
@@ -70,6 +71,7 @@ type ReplicantMap = {
 	"video-control": VideoControl;
 	"assets:interval-video": Assets[];
 	announcements: Announcements;
+	"playing-music": PlayingMusic;
 };
 
 export type {
@@ -97,4 +99,5 @@ export type {
 	DonationQueue,
 	BidChallenge,
 	Announcements,
+	PlayingMusic,
 };


### PR DESCRIPTION
resolve #724 

https://github.com/Hoishin/http-on-file-change からのリクエストを受けて再生中の曲名を更新できるようにした。

脱 spotify に伴い、曲名の prefix, suffix の設定を `spotify` から剥がした

```json:configschema.json
		"spotify": {
			"type": "object",
			"additionalProperties": false,
			"required": ["clientId", "clientSecret"],
			"properties": {
				"clientId": {"type": "string"},
				"clientSecret": {"type": "string"}
			}
		},
		"music": {
			"type": "object",
			"additionalProperties": false,
			"properties": {
				"textPrefix": {"type": "string", "default": ""},
				"textSuffix": {"type": "string", "default": ""}
			}
		},
```

セットアップ画面で表示されることを確認済み

```
curl --request PUT --url http://localhost:9090/playing-music \
--header 'content-type: application/json' \
--data '{"id": "hogehogesomeid","data": "EarthBound \"Twoson Hits the Road\" by djpretzel"}'
```

```json:cfg/rtainjapan-layouts.json
	"music": {
		"textSuffix": "(https://ocremix.org)"
	},
```

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/5fd1a224-08fc-421f-a619-3fd29f57f5ae)
