### PR TITLE
RTA in Japan Winter 2023 のセットアップ画面を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,11 @@
 				"width": 1920,
 				"height": 1080,
 				"singleInstance": true
+			},
+			{
+				"file": "setup-idol.html",
+				"width": 1920,
+				"height": 1030
 			}
 		],
 		"assetCategories": [

--- a/src/browser/graphics/components/lib/fit-text.tsx
+++ b/src/browser/graphics/components/lib/fit-text.tsx
@@ -6,7 +6,7 @@ import {
 	useState,
 } from "react";
 import {useElementResize} from "./use-element-resize";
-import {BoldText, ThinText, CreditText} from "./text";
+import {BoldText, ThinText, CreditText, HeavyText} from "./text";
 import {newlineString} from "./util";
 
 export const FitText: FunctionComponent<{
@@ -14,6 +14,7 @@ export const FitText: FunctionComponent<{
 	children: string | undefined | null;
 	thin?: boolean;
 	credit?: boolean;
+	heavy?: boolean;
 	style?: CSSProperties;
 	horizontalAlign?: "left" | "right" | "center";
 	verticalAlign?: "top" | "bottom" | "center";
@@ -51,6 +52,8 @@ export const FitText: FunctionComponent<{
 		? CreditText
 		: props.thin
 		? ThinText
+		: props.heavy
+		? HeavyText
 		: BoldText;
 
 	return (

--- a/src/browser/graphics/components/lib/text.ts
+++ b/src/browser/graphics/components/lib/text.ts
@@ -1,8 +1,14 @@
 import styled from "styled-components";
 
+export const HeavyText = styled.div`
+	font-family: m-plus-1p, sans-serif;
+	font-weight: 900; /* heavy */
+	font-style: normal;
+	white-space: nowrap;
+`;
 export const BoldText = styled.div`
 	font-family: m-plus-1p, sans-serif;
-	font-weight: 800; /* heavy */
+	font-weight: 800; /* extra-bold */
 	font-style: normal;
 	white-space: nowrap;
 `;

--- a/src/browser/graphics/views/setup-idol.tsx
+++ b/src/browser/graphics/views/setup-idol.tsx
@@ -9,7 +9,7 @@ import {useReplicant} from "../../use-replicant";
 import {useCurrentRun, useSchedule} from "../components/lib/hooks";
 import {Run} from "../../../nodecg/replicants";
 import moment from "moment";
-import {useCallback, useEffect, useRef, useState} from "react";
+import {Fragment, useCallback, useEffect, useRef, useState} from "react";
 import {Tweet} from "../components/tweet";
 import {Music} from "../components/music";
 import {setup} from "../styles/colors";
@@ -52,7 +52,8 @@ const Upcoming = () => {
 				left: "240px",
 				top: "240px",
 				display: "grid",
-				gridTemplateRows: "60px 50px 60px 40px 85px repeat(auto-fill, 30px)",
+				gridTemplateRows:
+					"60px 50px 60px 40px 85px repeat(auto-fill, 30px 5px)",
 				gridTemplateColumns: "820px",
 				alignContent: "start",
 				justifyContent: "stretch",
@@ -67,13 +68,7 @@ const Upcoming = () => {
 				次のゲーム
 			</BoldText>
 			<div>{/* empty */}</div>
-			<FitText
-				defaultSize={50}
-				horizontalAlign='center'
-				style={{
-					fontWeight: 900,
-				}}
-			>
+			<FitText defaultSize={50} horizontalAlign='center' heavy>
 				{nextRun.title.replace(/\\n/g, "")}
 			</FitText>
 			<BoldText
@@ -92,27 +87,29 @@ const Upcoming = () => {
 			<div>{/* empty */}</div>
 			{upcomingRuns.map((run) => {
 				return (
-					<div
-						key={run.pk}
-						style={{
-							fontSize: "22px",
-							display: "grid",
-							gridTemplateColumns: "100px 1fr",
-						}}
-					>
-						<BoldText>{calcStartTime(run)} ~</BoldText>
-						<BoldText
+					<Fragment key={run.pk}>
+						<div
 							style={{
-								overflow: "hidden",
-								whiteSpace: "nowrap",
-								textOverflow: "ellipsis",
+								fontSize: "22px",
+								display: "grid",
+								gridTemplateColumns: "100px 1fr",
 							}}
 						>
-							{/* Trackerの段階で改行文字を入れてもいいようにしておく */}
-							{run.title.replace(/\\n/g, "")} -{" "}
-							{run.category?.replace(/\\n/g, "")}
-						</BoldText>
-					</div>
+							<BoldText>{calcStartTime(run)} ~</BoldText>
+							<BoldText
+								style={{
+									overflow: "hidden",
+									whiteSpace: "nowrap",
+									textOverflow: "ellipsis",
+								}}
+							>
+								{/* Trackerの段階で改行文字を入れてもいいようにしておく */}
+								{run.title.replace(/\\n/g, "")} -{" "}
+								{run.category?.replace(/\\n/g, "")}
+							</BoldText>
+						</div>
+						<div>{/* empty */}</div>
+					</Fragment>
 				);
 			})}
 		</div>

--- a/src/browser/graphics/views/setup-idol.tsx
+++ b/src/browser/graphics/views/setup-idol.tsx
@@ -1,0 +1,296 @@
+import "modern-normalize";
+import "../styles/adobe-fonts.js";
+
+import gsap, {Power2} from "gsap";
+import {BoldText} from "../components/lib/text";
+import tagFanart from "../images/tag_fanart.svg";
+import tagTweet from "../images/tag_tweet.svg";
+import {useReplicant} from "../../use-replicant";
+import {useCurrentRun, useSchedule} from "../components/lib/hooks";
+import {Run} from "../../../nodecg/replicants";
+import moment from "moment";
+import {useCallback, useEffect, useRef, useState} from "react";
+import {Tweet} from "../components/tweet";
+import {Music} from "../components/music";
+import {setup} from "../styles/colors";
+import {swipeEnter, swipeExit} from "../components/lib/blur-swipe";
+import {useFitViewport} from "../components/lib/use-fit-viewport";
+import {render} from "../../render";
+import maskUpcomingImage from "../images/chalk_texture.png";
+import {FitText} from "../components/lib/fit-text";
+
+const Upcoming = () => {
+	const currentRun = useCurrentRun();
+	const schedule = useSchedule();
+
+	if (!currentRun || !schedule) {
+		return null;
+	}
+
+	const currrentRunIndex = currentRun.index;
+
+	const nextRun = currentRun;
+	const upcomingRuns = schedule?.slice(
+		currrentRunIndex + 1,
+		currrentRunIndex + 3,
+	);
+
+	let now = moment();
+	now.add(nextRun.setupDuration);
+	now.add(nextRun.runDuration);
+	const calcStartTime = (run: Run) => {
+		const startTime = now.format("HH:mm");
+		now.add(run.setupDuration);
+		now.add(run.runDuration);
+		return startTime;
+	};
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				left: "240px",
+				top: "240px",
+				display: "grid",
+				gridTemplateRows: "60px 50px 60px 40px 85px repeat(auto-fill, 30px)",
+				gridTemplateColumns: "820px",
+				alignContent: "start",
+				justifyContent: "stretch",
+				alignItems: "center",
+				background: `url(${maskUpcomingImage}) 0 0 / cover no-repeat`,
+				WebkitBackgroundClip: "text",
+				WebkitTextFillColor: "transparent",
+				color: "transparent",
+			}}
+		>
+			<BoldText style={{fontSize: "40px", textAlign: "center"}}>
+				次のゲーム
+			</BoldText>
+			<div>{/* empty */}</div>
+			<FitText
+				defaultSize={50}
+				horizontalAlign='center'
+				style={{
+					fontWeight: 900,
+				}}
+			>
+				{nextRun.title.replace(/\\n/g, "")}
+			</FitText>
+			<BoldText
+				style={{
+					fontSize: "22px",
+					textAlign: "center",
+					overflow: "hidden",
+					whiteSpace: "nowrap",
+					textOverflow: "ellipsis",
+				}}
+			>
+				{/* カテゴリ名は文字が小さいので改行はしない */}
+				{nextRun.category?.replace(/\\n/g, "")} - Runner:{" "}
+				{nextRun.runners.map((r) => r.name).join(", ")}
+			</BoldText>
+			<div>{/* empty */}</div>
+			{upcomingRuns.map((run) => {
+				return (
+					<div
+						key={run.pk}
+						style={{
+							fontSize: "22px",
+							display: "grid",
+							gridTemplateColumns: "100px 1fr",
+						}}
+					>
+						<BoldText>{calcStartTime(run)} ~</BoldText>
+						<BoldText
+							style={{
+								overflow: "hidden",
+								whiteSpace: "nowrap",
+								textOverflow: "ellipsis",
+							}}
+						>
+							{/* Trackerの段階で改行文字を入れてもいいようにしておく */}
+							{run.title.replace(/\\n/g, "")} -{" "}
+							{run.category?.replace(/\\n/g, "")}
+						</BoldText>
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
+const Sponsor = () => {
+	const assets = useReplicant(`assets:sponsor-setup`);
+	const imageRef = useRef<HTMLImageElement>(null);
+	const [currentSponsor, setCurrentSponsor] = useState(0);
+
+	useEffect(() => {
+		if (!assets) {
+			return;
+		}
+		const tl = gsap.timeline();
+		const initialize = () => {
+			const sponsorUrl = assets[currentSponsor]?.url;
+			if (!sponsorUrl) {
+				return;
+			}
+
+			tl.set(imageRef.current, {
+				maskImage:
+					"linear-gradient(to right, rgba(0,0,0,0) 100%, rgba(0,0,0,1) 120%)",
+			});
+
+			tl.set(imageRef.current, {opacity: 1});
+
+			tl.set(imageRef.current, {attr: {src: sponsorUrl}});
+			tl.add(swipeEnter(imageRef), "<+=0.3");
+			tl.add(swipeExit(imageRef), "<+=40");
+
+			tl.set(imageRef.current, {opacity: 0});
+
+			tl.call(() => {
+				setCurrentSponsor((currentSponsor) =>
+					assets.length - 1 <= currentSponsor ? 0 : currentSponsor + 1,
+				);
+			});
+		};
+
+		initialize();
+		return () => {
+			tl.revert();
+		};
+	}, [assets, currentSponsor]);
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				top: "620px",
+				right: 0,
+				width: "440px",
+				height: "360px",
+				display: "grid",
+				gridTemplateColumns: "1fr",
+				willChange: "transoform",
+			}}
+		>
+			<div
+				style={{
+					placeSelf: "stretch",
+					display: "grid",
+					placeContent: "center",
+					placeItems: "center",
+					background: setup.frameBg,
+					borderWidth: "2px 0 2px 2px",
+					borderStyle: "solid",
+					borderColor: setup.frameBorder,
+					borderRadius: "7px 0 0 7px",
+				}}
+			>
+				<img ref={imageRef}></img>
+			</div>
+		</div>
+	);
+};
+
+const TweetContainer = () => {
+	const tweetTag = useRef(null);
+	const fanartTag = useRef(null);
+	const tweetRef = useRef(null);
+	const transitionTimeline = useCallback(() => {
+		const tl = gsap.timeline();
+		tl.to([tweetTag.current, tweetRef.current], {
+			x: -440,
+			duration: 1,
+			ease: Power2.easeOut,
+		});
+		tl.to(
+			[tweetTag.current, tweetRef.current],
+			{x: 0, duration: 1, ease: Power2.easeOut},
+			"+=10",
+		);
+		return tl;
+	}, []);
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				top: "150px",
+				left: "1890px",
+				width: "470px",
+				display: "grid",
+				gridTemplateColumns: "30px 440px",
+				gridTemplateRows: "81px 1fr",
+			}}
+		>
+			<img
+				ref={tweetTag}
+				src={tagTweet}
+				width={30}
+				height={88}
+				style={{
+					gridRow: "1 / 2",
+					gridColumn: "1 / 2",
+					alignSelf: "start",
+					willChange: "transform",
+				}}
+			></img>
+			<img
+				ref={fanartTag}
+				src={tagFanart}
+				width={30}
+				height={98}
+				style={{
+					display: "none", // TODO: remove after adding fanart
+					gridRow: "2 / 3",
+					gridColumn: "1 / 2",
+					alignSelf: "start",
+					willChange: "transform",
+				}}
+			></img>
+			<div
+				ref={tweetRef}
+				style={{
+					gridRow: "1 / 3",
+					gridColumn: "2 / 3",
+					alignSelf: "start",
+					justifySelf: "stretch",
+					padding: "50px",
+					borderColor: setup.frameBorder,
+					borderStyle: "solid",
+					borderWidth: "2px 0 2px 2px",
+					borderRadius: "7px 0 0 7px",
+					background: setup.frameBg,
+					willChange: "transform",
+				}}
+			>
+				<Tweet onShow={transitionTimeline}></Tweet>
+			</div>
+		</div>
+	);
+};
+
+const App = () => {
+	const ref = useRef<HTMLDivElement>(null);
+	useFitViewport(ref);
+	return (
+		<div
+			ref={ref}
+			style={{
+				position: "absolute",
+				width: "1920px",
+				height: "1030px",
+				overflow: "hidden",
+				color: setup.text,
+			}}
+		>
+			<Upcoming></Upcoming>
+			<Music></Music>
+			<Sponsor></Sponsor>
+			<TweetContainer></TweetContainer>
+		</div>
+	);
+};
+
+render(<App />);


### PR DESCRIPTION
resolves #731 

- 「次のゲーム」表示がこれまでと大きく変わる特別仕様なので、別の graphic として開発しました

# screenshot

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/7ad27f46-615c-4297-b307-32a327ac74a8)

長いゲーム名は縮小して表示します

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/9718fe5b-87af-4beb-bc7f-cb7ee0f6b330)

カテゴリ名が長いため省略される場合

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/e6ca6d8c-91a6-45d9-afa3-f8677a256c2f)

On deck で省略される場合

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/d2e3e4cf-0793-44f0-bb47-19f6d5bab474)

Twitter 表示

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/69bcba2d-97db-429c-a4e3-eb356a6b7451)

