### PR TITLE
RiJW2023 セットアップレイアウトをレイヤー毎に表示できるようにした

### DIFF
--- a/src/browser/graphics/views/setup-idol.tsx
+++ b/src/browser/graphics/views/setup-idol.tsx
@@ -19,6 +19,9 @@ import {render} from "../../render";
 import maskUpcomingImage from "../images/chalk_texture.png";
 import {FitText} from "../components/lib/fit-text";
 
+const params = new URLSearchParams(location.search);
+const layer = params.get("layer") ?? "";
+
 const Upcoming = () => {
 	const currentRun = useCurrentRun();
 	const schedule = useSchedule();
@@ -282,10 +285,14 @@ const App = () => {
 				color: setup.text,
 			}}
 		>
-			<Upcoming></Upcoming>
-			<Music></Music>
-			<Sponsor></Sponsor>
-			<TweetContainer></TweetContainer>
+			{(!layer || layer === "back") && <Upcoming></Upcoming>}
+			{(!layer || layer === "front") && (
+				<Fragment>
+					<Music></Music>
+					<Sponsor></Sponsor>
+					<TweetContainer></TweetContainer>
+				</Fragment>
+			)}
 		</div>
 	);
 };

--- a/src/browser/graphics/views/setup-idol.tsx
+++ b/src/browser/graphics/views/setup-idol.tsx
@@ -20,7 +20,7 @@ import maskUpcomingImage from "../images/chalk_texture.png";
 import {FitText} from "../components/lib/fit-text";
 
 const params = new URLSearchParams(location.search);
-const layer = params.get("layer") ?? "";
+const layer = params.get("layer");
 
 const Upcoming = () => {
 	const currentRun = useCurrentRun();


### PR DESCRIPTION
ぱんつさんの要望より。

- クエリパラメタ `layer` で表示するレイヤーを分けます。指定なしの時はレイヤー分けせず表示
- `layer=front` の場合、前面に表示したい要素のみ表示します
  - 次のゲーム表示以外
- `layer=back` の場合、後面に表示
  - 次のゲーム表示