### PR TITLE
幕間動画再生時のリサイズを修正する

### DIFF
--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -4,7 +4,6 @@ import "../styles/adobe-fonts.js";
 import {useEffect} from "react";
 import {useReplicant} from "../../use-replicant";
 import {render} from "../../render.js";
-import styled from "styled-components";
 
 const videoControlRep = nodecg.Replicant("video-control");
 

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -4,8 +4,17 @@ import "../styles/adobe-fonts.js";
 import {useEffect} from "react";
 import {useReplicant} from "../../use-replicant";
 import {render} from "../../render.js";
+import styled from "styled-components";
 
 const videoControlRep = nodecg.Replicant("video-control");
+
+const VideoContainer = styled.div`
+	width: 100vw;
+	height: 100vh;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
 
 const App = () => {
 	const videoControl = useReplicant("video-control");
@@ -86,14 +95,16 @@ const App = () => {
 	}, []);
 
 	return (
-		<video
-			ref={onVideoRendered}
-			src={videoControl?.path}
-			style={{
-				minWidth: "100vw",
-				minHeight: "100vh",
-			}}
-		/>
+		<VideoContainer>
+			<video
+				ref={onVideoRendered}
+				src={videoControl?.path}
+				style={{
+					maxWidth: "100%",
+					maxHeight: "100%",
+				}}
+			/>
+		</VideoContainer>
 	);
 };
 

--- a/src/browser/graphics/views/interval-video.tsx
+++ b/src/browser/graphics/views/interval-video.tsx
@@ -8,14 +8,6 @@ import styled from "styled-components";
 
 const videoControlRep = nodecg.Replicant("video-control");
 
-const VideoContainer = styled.div`
-	width: 100vw;
-	height: 100vh;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-`;
-
 const App = () => {
 	const videoControl = useReplicant("video-control");
 
@@ -95,16 +87,15 @@ const App = () => {
 	}, []);
 
 	return (
-		<VideoContainer>
-			<video
-				ref={onVideoRendered}
-				src={videoControl?.path}
-				style={{
-					maxWidth: "100%",
-					maxHeight: "100%",
-				}}
-			/>
-		</VideoContainer>
+		<video
+			ref={onVideoRendered}
+			src={videoControl?.path}
+			style={{
+				width: "100vw",
+				height: "100vh",
+				objectFit: "contain",
+			}}
+		/>
 	);
 };
 


### PR DESCRIPTION
- `video` タグは画面全体に描画し、 `object-fit: contain` で内側に収まるようにしました