### PR TITLE
タイマーリセット時に走者タイムを null で埋めるようにする

### DIFF
--- a/src/extension/timekeeping.ts
+++ b/src/extension/timekeeping.ts
@@ -88,7 +88,7 @@ export const timekeeping = (nodecg: NodeCG) => {
 		}
 		stop();
 		setSeconds(timerRep.value, 0);
-		timerRep.value.results = [];
+		timerRep.value.results = [null, null, null, null];
 	};
 
 	/**


### PR DESCRIPTION
- `timerRep.value.results` が `[]` のとき、インデックスが一番若い走者以外が完走すると、若いインデックスの要素がスキーマエラーになる
  - `undefined` がダメなのかも？何が入って制約に違反しているのかは見れてない

```
UNCAUGHT EXCEPTION! NodeCG will now exit.
Error: Invalid value rejected for replicant "timer" in namespace "rtainjapan-layouts":
results/0 must be null, data/results/0 must be object, data/results/0 must match exactly one schema in oneOf
    at ServerReplicant.validate (webpack://nodecg/src/shared/replicants.shared.ts:270:12)
    at Object.set (webpack://nodecg/src/shared/replicants.shared.ts:439:14)
    at Object.completeRunner (/opt/nodecg/bundles/rtainjapan-layouts/src/extension/timekeeping.ts:153:37)
    at <anonymous> (webpack://nodecg/src/server/api.server.ts:164:16)
    at Array.forEach (<anonymous>)
    at Socket.<anonymous> (webpack://nodecg/src/server/api.server.ts:162:28)
    at Socket.emit (node:events:525:35)
    at Socket.emit (node:domain:489:12)
    at Socket.emitUntyped (/opt/nodecg/node_modules/socket.io/dist/typed-events.js:69:22)
    at /opt/nodecg/node_modules/socket.io/dist/socket.js:614:39
```

- 暫定対応として、リセット時に4スロット分 `null` で埋めるようにしました。 replicant の defaultValue と同じなので問題ないはず

完走した走者以外の results に関係ない値が入っていないことは確認した

![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/33190610/57eb38e5-c61b-45ab-8a9a-afecc85cfe51)
