### PR TITLE
走者4人が完走・リタイアしたらタイマーが止まるようにする

### DIFF
--- a/src/extension/timekeeping.ts
+++ b/src/extension/timekeeping.ts
@@ -134,7 +134,10 @@ export const timekeeping = (nodecg: NodeCG) => {
 					!runner.name || (timerRep.value && timerRep.value.results[index]),
 				),
 		);
-		if (allRunnersFinished) {
+		const onSlotRunnersAreFinished = timerRep.value.results.every(
+			(result) => result !== null,
+		);
+		if (allRunnersFinished || onSlotRunnersAreFinished) {
 			stop();
 			timerRep.value.timerState = "Finished";
 		}


### PR DESCRIPTION
#738 の暫定対応

- リセット時に `null` で埋めているタイマーの各走者の結果に null がなければタイマーを止めるようにした