### PR TITLE
Twitter/ファンアート表示機能仮対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,15 @@
 				"file": "donations.html",
 				"width": 6,
 				"headerColor": "#00BEBE",
-				"workspace": "3-donations"
+				"workspace": "3-reactions"
+			},
+			{
+				"name": "twitter",
+				"title": "Twitter投稿/ファンアート",
+				"file": "twitter.html",
+				"width": 6,
+				"headerColor": "#00BEBE",
+				"workspace": "3-reactions"
 			},
 			{
 				"name": "video-control",

--- a/schemas/tweets-temp.json
+++ b/schemas/tweets-temp.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema",
+
+	"type": "array",
+	"items": {
+		"type": "object",
+		"properties": {
+			"text": {"type": "string"},
+			"name": {"type": "string"},
+			"image": {"type": "string"}
+		},
+		"additionalProperties": false,
+		"required": ["text", "name"]
+	},
+	"default": []
+}

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -1,0 +1,63 @@
+import styled from "styled-components";
+import List from "@mui/material/List";
+import {TweetAdd} from "./tweet-add";
+import {TweetItem} from "./tweet-item";
+import {useReplicant} from "../../../use-replicant";
+
+const Container = styled.div``;
+
+const tweetsTempRep = nodecg.Replicant("tweets-temp");
+
+export const Twitter = () => {
+	const tweets = useReplicant("tweets-temp");
+
+	return (
+		<Container>
+			<List>
+				<TweetAdd
+					onSubmit={(tweets, onSuccess) => {
+						if (tweetsTempRep.value && tweets.text && tweets.name) {
+							tweetsTempRep.value.push(tweets);
+							onSuccess();
+						}
+					}}
+				/>
+				{tweets?.map((tweet, index) => (
+					<TweetItem
+						key={index}
+						tweet={tweet}
+						onSubmit={(tweet, onSuccess) => {
+							if (tweetsTempRep.value) {
+								tweetsTempRep.value = [
+									...tweets.slice(0, index),
+									...tweets.slice(index + 1),
+								];
+								nodecg.sendMessage("showTweet", tweet);
+								onSuccess();
+							}
+						}}
+						onSubmitFanArt={(tweet, onSuccess) => {
+							if (tweetsTempRep.value) {
+								tweetsTempRep.value = [
+									...tweets.slice(0, index),
+									...tweets.slice(index + 1),
+								];
+								nodecg.sendMessage("showFanArtTweet", tweet);
+								onSuccess();
+							}
+						}}
+						onDelete={(onSuccess) => {
+							if (tweetsTempRep.value) {
+								tweetsTempRep.value = [
+									...tweets.slice(0, index),
+									...tweets.slice(index + 1),
+								];
+								onSuccess();
+							}
+						}}
+					/>
+				))}
+			</List>
+		</Container>
+	);
+};

--- a/src/browser/dashboard/components/twitter/tweet-add.tsx
+++ b/src/browser/dashboard/components/twitter/tweet-add.tsx
@@ -1,0 +1,97 @@
+import IconButton, {IconButtonProps} from "@mui/material/IconButton";
+import ListItem from "@mui/material/ListItem";
+import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
+import ListItemText from "@mui/material/ListItemText";
+import AddIcon from "@mui/icons-material/Add";
+import {useState} from "react";
+import {TweetsTemp} from "../../../../nodecg/generated";
+
+type Tweet = TweetsTemp[number];
+
+type Props = {
+	onSubmit: (tweet: Tweet, onSuccess: () => void) => void;
+};
+
+type ButtonProps = Pick<IconButtonProps, "onClick">;
+
+const AddButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<AddIcon />
+		</IconButton>
+	);
+};
+
+export const TweetAdd = ({onSubmit}: Props) => {
+	const [tweet, setTweet] = useState<Tweet>({
+		text: "",
+		name: "",
+		image: "",
+	});
+
+	const clearInputs = () => {
+		setTweet({
+			text: "",
+			name: "",
+			image: "",
+		});
+	};
+
+	return (
+		<ListItem>
+			<ListItemText
+				primary={
+					<>
+						<input
+							value={tweet.name}
+							onChange={({currentTarget: {value}}) => {
+								setTweet((tweet) => ({
+									...tweet,
+									name: value,
+								}));
+							}}
+							placeholder='ユーザー名'
+							style={{
+								marginRight: "10px",
+							}}
+						/>
+						<input
+							value={tweet.image}
+							onChange={({currentTarget: {value}}) => {
+								setTweet((tweet) => ({
+									...tweet,
+									image: value,
+								}));
+							}}
+							size={50}
+							placeholder='画像URL(ファンアートを表示したい場合入力してください)'
+						/>
+					</>
+				}
+				secondary={
+					<textarea
+						value={tweet.text}
+						onChange={({currentTarget: {value}}) => {
+							setTweet((tweet) => ({
+								...tweet,
+								text: value,
+							}));
+						}}
+						placeholder='本文'
+						cols={100}
+						rows={4}
+					/>
+				}
+			/>
+			<ListItemSecondaryAction>
+				<AddButton
+					onClick={() => {
+						onSubmit(tweet, () => {
+							clearInputs();
+						});
+					}}
+				/>
+			</ListItemSecondaryAction>
+		</ListItem>
+	);
+};

--- a/src/browser/dashboard/components/twitter/tweet-item.tsx
+++ b/src/browser/dashboard/components/twitter/tweet-item.tsx
@@ -1,10 +1,10 @@
 import IconButton, {IconButtonProps} from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 import ListItem from "@mui/material/ListItem";
 import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 import CheckIcon from "@mui/icons-material/Check";
-import Favorite from "@mui/icons-material/Favorite";
 import DeleteIcon from "@mui/icons-material/Delete";
 import {useEffect, useState} from "react";
 import {TweetsTemp} from "../../../../nodecg/generated";
@@ -22,24 +22,21 @@ type ButtonProps = Pick<IconButtonProps, "onClick">;
 
 const DeleteButton = (props: ButtonProps) => {
 	return (
-		<IconButton {...props}>
-			<DeleteIcon />
-		</IconButton>
+		<Tooltip title='ツイートを削除'>
+			<IconButton {...props}>
+				<DeleteIcon />
+			</IconButton>
+		</Tooltip>
 	);
 };
 
 const SubmitButton = (props: ButtonProps) => {
 	return (
-		<IconButton {...props}>
-			<CheckIcon />
-		</IconButton>
-	);
-};
-const SubmitFanArtButton = (props: ButtonProps) => {
-	return (
-		<IconButton {...props}>
-			<Favorite />
-		</IconButton>
+		<Tooltip title='ツイート表示/ファンアート表示を実行'>
+			<IconButton {...props}>
+				<CheckIcon />
+			</IconButton>
+		</Tooltip>
 	);
 };
 
@@ -88,20 +85,12 @@ export const TweetItem = ({
 				<>
 					<SubmitButton
 						onClick={() => {
-							onSubmit(tweet, () => {});
+							tweet.image
+								? onSubmitFanArt(tweet, () => {})
+								: onSubmit(tweet, () => {});
 						}}
 					/>
 					/
-					{tweet.image && (
-						<>
-							<SubmitFanArtButton
-								onClick={() => {
-									onSubmitFanArt(tweet, () => {});
-								}}
-							/>
-							/
-						</>
-					)}
 					<DeleteButton
 						onClick={() => {
 							onDelete(() => {});

--- a/src/browser/dashboard/components/twitter/tweet-item.tsx
+++ b/src/browser/dashboard/components/twitter/tweet-item.tsx
@@ -1,0 +1,115 @@
+import IconButton, {IconButtonProps} from "@mui/material/IconButton";
+import ListItem from "@mui/material/ListItem";
+import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import CheckIcon from "@mui/icons-material/Check";
+import Favorite from "@mui/icons-material/Favorite";
+import DeleteIcon from "@mui/icons-material/Delete";
+import {useEffect, useState} from "react";
+import {TweetsTemp} from "../../../../nodecg/generated";
+
+type Tweet = TweetsTemp[number];
+
+type Props = {
+	tweet: Tweet;
+	onSubmit: (tweet: Tweet, onSuccess: () => void) => void;
+	onSubmitFanArt: (tweet: Tweet, onSuccess: () => void) => void;
+	onDelete: (onSuccess: () => void) => void;
+};
+
+type ButtonProps = Pick<IconButtonProps, "onClick">;
+
+const DeleteButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<DeleteIcon />
+		</IconButton>
+	);
+};
+
+const SubmitButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<CheckIcon />
+		</IconButton>
+	);
+};
+const SubmitFanArtButton = (props: ButtonProps) => {
+	return (
+		<IconButton {...props}>
+			<Favorite />
+		</IconButton>
+	);
+};
+
+export const TweetItem = ({
+	tweet: propTweet,
+	onSubmit,
+	onSubmitFanArt,
+	onDelete,
+}: Props) => {
+	const [tweet, setTweet] = useState<Tweet>(propTweet);
+
+	useEffect(() => {
+		setTweet(propTweet);
+	}, [propTweet]);
+
+	return (
+		<ListItem>
+			<ListItemText
+				primary={tweet.name}
+				secondary={
+					<>
+						<Typography
+							variant='body2'
+							style={{
+								maxWidth: "500px",
+							}}
+						>
+							{tweet.text}
+						</Typography>
+						{tweet.image && (
+							<a href={tweet.image} target='_blank'>
+								<img
+									src={tweet.image}
+									style={{
+										maxWidth: "300px",
+										maxHeight: "100px",
+									}}
+								/>
+							</a>
+						)}
+					</>
+				}
+			/>
+			<ListItemSecondaryAction>
+				(
+				<>
+					<SubmitButton
+						onClick={() => {
+							onSubmit(tweet, () => {});
+						}}
+					/>
+					/
+					{tweet.image && (
+						<>
+							<SubmitFanArtButton
+								onClick={() => {
+									onSubmitFanArt(tweet, () => {});
+								}}
+							/>
+							/
+						</>
+					)}
+					<DeleteButton
+						onClick={() => {
+							onDelete(() => {});
+						}}
+					/>
+				</>
+				)
+			</ListItemSecondaryAction>
+		</ListItem>
+	);
+};

--- a/src/browser/dashboard/views/twitter.tsx
+++ b/src/browser/dashboard/views/twitter.tsx
@@ -1,0 +1,22 @@
+import "../styles/global";
+
+import createTheme from "@mui/material/styles/createTheme";
+import ThemeProvider from "@mui/material/styles/ThemeProvider";
+import {Twitter} from "../components/twitter";
+import {render} from "../../render";
+
+const theme = createTheme();
+
+const App = () => {
+	return (
+		<ThemeProvider theme={theme}>
+			<Twitter />
+		</ThemeProvider>
+	);
+};
+
+render(
+	<>
+		<App />
+	</>,
+);

--- a/src/browser/graphics/components/fan-art-tweet.tsx
+++ b/src/browser/graphics/components/fan-art-tweet.tsx
@@ -1,31 +1,29 @@
 import gsap from "gsap";
 import iconTwitter from "../images/icon/icon_twitter.svg";
-import {useEffect, useMemo, useState} from "react";
+import {useEffect, useMemo, useRef, useState} from "react";
 import {TweetsTemp} from "../../../nodecg/generated/tweets-temp";
 import {ThinText} from "./lib/text";
 
-export const Tweet = ({
+export const FanArtTweet = ({
 	onShow,
 }: {
-	onShow?: () => gsap.core.Tween | gsap.core.Timeline;
+	onShow?: (width: number) => gsap.core.Tween | gsap.core.Timeline;
 }) => {
 	const [user, setUser] = useState("");
 	const [text, setText] = useState("");
+	const [image, setImage] = useState("");
 	const tl = useMemo(() => gsap.timeline(), []);
+	const imgRef = useRef<HTMLImageElement>(null);
 
 	useEffect(() => {
 		const listener = (tweet: TweetsTemp[number]) => {
-			tl.call(() => {
-				setUser(tweet.name);
-				setText(tweet.text);
-			});
-			if (onShow) {
-				tl.add(onShow(), "+=0.2");
-			}
+			setUser(tweet.name);
+			setText(tweet.text);
+			setImage(tweet.image ?? "");
 		};
-		nodecg.listenFor("showTweet", listener);
+		nodecg.listenFor("showFanArtTweet", listener);
 		return () => {
-			nodecg.unlisten("showTweet", listener);
+			nodecg.unlisten("showFanArtTweet", listener);
 		};
 	}, [onShow, tl]);
 
@@ -33,8 +31,9 @@ export const Tweet = ({
 		<div
 			style={{
 				display: "grid",
-				gap: "20px",
-				gridTemplateRows: "auto auto",
+				rowGap: "20px",
+				gridTemplateRows: "30px auto",
+				gridTemplateColumns: "340px 50px 1fr",
 				alignContent: "center",
 				justifyContent: "stretch",
 			}}
@@ -43,6 +42,8 @@ export const Tweet = ({
 				style={{
 					display: "grid",
 					gridTemplateColumns: "auto auto",
+					gridRow: "1 / 2",
+					gridColumn: "1 / 2",
 					justifyContent: "start",
 					alignItems: "end",
 					justifyItems: "start",
@@ -62,10 +63,34 @@ export const Tweet = ({
 					lineHeight: "30px",
 					whiteSpace: "normal",
 					wordBreak: "break-all",
+					gridRow: "2 / 3",
+					gridColumn: "1 / 2",
 				}}
 			>
 				{text}
 			</ThinText>
+			<div
+				style={{
+					gridRow: "1 / 3",
+					gridColumn: "2 / 3",
+				}}
+			></div>
+			<img
+				ref={imgRef}
+				src={image}
+				onLoad={() => {
+					if (onShow) {
+						tl.add(onShow(imgRef.current?.clientWidth ?? 0), "+=0.2");
+					}
+				}}
+				style={{
+					gridRow: "1 / 3",
+					gridColumn: "3 / 4",
+					maxWidth: "340px",
+					maxHeight: "340px",
+					objectFit: "cover",
+				}}
+			></img>
 		</div>
 	);
 };

--- a/src/browser/graphics/components/sponsor/index.tsx
+++ b/src/browser/graphics/components/sponsor/index.tsx
@@ -9,7 +9,7 @@ import {
 import {useReplicant} from "../../../use-replicant";
 import {background, border} from "../../styles/colors";
 import {swipeEnter, swipeExit} from "../lib/blur-swipe";
-import {Tweets} from "../../../../nodecg/generated/tweets";
+import {TweetsTemp} from "../../../../nodecg/generated/tweets-temp";
 import iconTwitter from "../../images/icon/icon_twitter.svg";
 import {ThinText} from "../lib/text";
 
@@ -69,9 +69,9 @@ export const Sponsor: FunctionComponent<{
 			});
 		};
 
-		const listener = (tweet: Tweets[number]) => {
+		const listener = (tweet: TweetsTemp[number]) => {
 			tl.call(() => {
-				setUser(tweet.user.screenName);
+				setUser(tweet.name);
 				setText(tweet.text);
 			});
 		};

--- a/src/browser/graphics/views/setup-idol.tsx
+++ b/src/browser/graphics/views/setup-idol.tsx
@@ -11,6 +11,7 @@ import {Run} from "../../../nodecg/replicants";
 import moment from "moment";
 import {Fragment, useCallback, useEffect, useRef, useState} from "react";
 import {Tweet} from "../components/tweet";
+import {FanArtTweet} from "../components/fan-art-tweet";
 import {Music} from "../components/music";
 import {setup} from "../styles/colors";
 import {swipeEnter, swipeExit} from "../components/lib/blur-swipe";
@@ -197,6 +198,7 @@ const TweetContainer = () => {
 	const tweetTag = useRef(null);
 	const fanartTag = useRef(null);
 	const tweetRef = useRef(null);
+	const fanArtRef = useRef(null);
 	const transitionTimeline = useCallback(() => {
 		const tl = gsap.timeline();
 		tl.to([tweetTag.current, tweetRef.current], {
@@ -207,7 +209,21 @@ const TweetContainer = () => {
 		tl.to(
 			[tweetTag.current, tweetRef.current],
 			{x: 0, duration: 1, ease: Power2.easeOut},
-			"+=10",
+			"+=15",
+		);
+		return tl;
+	}, []);
+	const transitionFanArtTimeline = useCallback((width: number) => {
+		const tl = gsap.timeline();
+		tl.to([fanartTag.current, fanArtRef.current], {
+			x: (width + 490) * -1,
+			duration: 1,
+			ease: Power2.easeOut,
+		});
+		tl.to(
+			[fanartTag.current, fanArtRef.current],
+			{x: 0, duration: 1, ease: Power2.easeOut},
+			"+=20",
 		);
 		return tl;
 	}, []);
@@ -218,9 +234,8 @@ const TweetContainer = () => {
 				position: "absolute",
 				top: "150px",
 				left: "1890px",
-				width: "470px",
 				display: "grid",
-				gridTemplateColumns: "30px 440px",
+				gridTemplateColumns: "30px 440px auto",
 				gridTemplateRows: "81px 1fr",
 			}}
 		>
@@ -242,7 +257,6 @@ const TweetContainer = () => {
 				width={30}
 				height={98}
 				style={{
-					display: "none", // TODO: remove after adding fanart
 					gridRow: "2 / 3",
 					gridColumn: "1 / 2",
 					alignSelf: "start",
@@ -266,6 +280,24 @@ const TweetContainer = () => {
 				}}
 			>
 				<Tweet onShow={transitionTimeline}></Tweet>
+			</div>
+			<div
+				ref={fanArtRef}
+				style={{
+					gridRow: "1 / 3",
+					gridColumn: "2 / 4",
+					alignSelf: "start",
+					justifySelf: "stretch",
+					padding: "50px",
+					borderColor: setup.frameBorder,
+					borderStyle: "solid",
+					borderWidth: "2px 0 2px 2px",
+					borderRadius: "7px 0 0 7px",
+					background: setup.frameBg,
+					willChange: "transform",
+				}}
+			>
+				<FanArtTweet onShow={transitionFanArtTimeline} />
 			</div>
 		</div>
 	);

--- a/src/nodecg/messages.d.ts
+++ b/src/nodecg/messages.d.ts
@@ -1,8 +1,11 @@
-import {Tweets, Run} from "./replicants";
+import {Tweets, Run, TweetsTemp} from "./replicants";
 
 export type MessageMap = {
 	showTweet: {
-		data: Tweets[number];
+		data: TweetsTemp[number];
+	};
+	showFanArtTweet: {
+		data: TweetsTemp[number];
 	};
 	"twitter:logout": {};
 	"twitter:startLogin": {

--- a/src/nodecg/replicants.d.ts
+++ b/src/nodecg/replicants.d.ts
@@ -3,6 +3,7 @@ import {CurrentRun} from "./generated/current-run";
 import {NextRun} from "./generated/next-run";
 import {Schedule} from "./generated/schedule";
 import {Tweets} from "./generated/tweets";
+import {TweetsTemp} from "./generated/tweets-temp";
 import {Timer} from "./generated/timer";
 import {Spotify} from "./generated/spotify";
 import {Spreadsheet} from "./generated/spreadsheet";
@@ -50,6 +51,7 @@ type ReplicantMap = {
 	spreadsheet: Spreadsheet;
 	timer: Timer;
 	tweets: Tweets;
+	"tweets-temp": TweetsTemp;
 	"obs-status": ObsStatus;
 	obs: Obs;
 	"obs-crop-inputs": ObsCropInputs;
@@ -82,6 +84,7 @@ export type {
 	NextRun,
 	Schedule,
 	Tweets,
+	TweetsTemp,
 	Timer,
 	Spotify,
 	Spreadsheet,


### PR DESCRIPTION
#635 の仮対応です。
- ダッシュボードのworkspace名`3-donations`を`3-reactions`に変更
- Twitter表示用のReplicantを仮実装(後々の改修で調整)
- ダッシュボードにTwitter/ファンアート登録用のコンポーネント追加
  - ユーザー名、本文、画像URLを直接入力する形式(仮対応)
  - チェックマークを押すとTwitter表示、ハートマークを押すとファンアート表示
  - 後々puppeteerから自動取得する対応を実施、録画PC内からDockerでサーバー起動する予定
- Twitter表示の時間を10→15秒、ファンアートの表示時間を20秒に設定(設計書準拠)

ダッシュボード
![image](https://github.com/RTAinJapan/rtainjapan-layouts/assets/13300790/7c7d466c-37a8-4264-9e1f-e746ca2cfec8)
待機画面
![Screenshot 2023-12-28 04-17-19](https://github.com/RTAinJapan/rtainjapan-layouts/assets/13300790/a73c8844-5e51-467e-9d52-c058d1707343)


