### PR TITLE
ネームプレートの同期がズレるのを修正した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"klona": "^2.0.6",
 				"moment": "^2.29.4",
 				"obs-websocket-js": "^5.0.2",
+				"react-transition-group": "^4.4.5",
 				"tslib": "^2.5.0",
 				"uuid": "^9.0.0",
 				"ws": "^8.13.0"
@@ -2728,8 +2729,7 @@
 		"node_modules/csstype": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-			"dev": true
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
 		},
 		"node_modules/d": {
 			"version": "1.0.1",
@@ -3065,7 +3065,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
 			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.8.7",
 				"csstype": "^3.0.2"
@@ -4944,7 +4943,6 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -5376,7 +5374,6 @@
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -6096,7 +6093,6 @@
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6890,7 +6886,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -6899,7 +6894,6 @@
 		},
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/proxy-addr": {
@@ -6994,7 +6988,6 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -7006,7 +6999,6 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
 			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
@@ -7046,7 +7038,6 @@
 			"version": "4.4.5",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
 			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.5.5",
 				"dom-helpers": "^5.0.1",
@@ -7428,7 +7419,6 @@
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
 			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"klona": "^2.0.6",
 		"moment": "^2.29.4",
 		"obs-websocket-js": "^5.0.2",
+		"react-transition-group": "^4.4.5",
 		"tslib": "^2.5.0",
 		"uuid": "^9.0.0",
 		"ws": "^8.13.0"

--- a/src/browser/graphics/components/nameplate/sync-display.tsx
+++ b/src/browser/graphics/components/nameplate/sync-display.tsx
@@ -1,0 +1,68 @@
+import gsap from "gsap";
+import {ReactNode, createContext, useEffect, useState} from "react";
+import {useReplicant} from "../../../use-replicant";
+
+type DisplayLabel = "name" | "twitter" | "twitch" | "nico";
+
+export const SyncDisplayContext = createContext<DisplayLabel>("name");
+
+export const SyncDisplayProvider = ({children}: {children: ReactNode}) => {
+	const [display, setDisplay] = useState<DisplayLabel>("name");
+
+	const currentRun = useReplicant("current-run");
+
+	const participantSocials = [
+		...(currentRun?.runners.map((runner) =>
+			[
+				runner.twitter ? "twitter" : null,
+				runner.twitch ? "twitch" : null,
+				runner.nico ? "nico" : null,
+			].filter((v): v is DisplayLabel => v !== null),
+		) ?? []),
+		...(currentRun?.commentators.map((commentator) =>
+			[
+				commentator?.twitter ? "twitter" : null,
+				commentator?.twitch ? "twitch" : null,
+				commentator?.nico ? "nico" : null,
+			].filter((v): v is DisplayLabel => v !== null),
+		) ?? []),
+	];
+
+	const displayTwitter = participantSocials.some((socials) =>
+		socials.includes("twitter"),
+	);
+	const displayTwitch = participantSocials.some((socials) =>
+		socials.includes("twitch"),
+	);
+	const displayNico = participantSocials.some((socials) =>
+		socials.includes("nico"),
+	);
+
+	useEffect(() => {
+		const tl = gsap.timeline({repeat: -1});
+		const displays: DisplayLabel[] = [
+			displayTwitter ? "twitter" : null,
+			displayTwitch ? "twitch" : null,
+			displayNico ? "nico" : null,
+			"name",
+		].filter((v): v is DisplayLabel => v !== null);
+		for (const social of displays) {
+			tl.call(
+				(s) => {
+					setDisplay(s);
+				},
+				[social],
+				"+=31", // 表示時間の30秒と切り替え時間の1秒
+			);
+		}
+		return () => {
+			tl.kill();
+		};
+	}, [displayTwitter, displayTwitch, displayNico]);
+
+	return (
+		<SyncDisplayContext.Provider value={display}>
+			{children}
+		</SyncDisplayContext.Provider>
+	);
+};

--- a/src/browser/graphics/components/nameplate/sync-display.tsx
+++ b/src/browser/graphics/components/nameplate/sync-display.tsx
@@ -1,6 +1,7 @@
 import gsap from "gsap";
 import {ReactNode, createContext, useEffect, useState} from "react";
 import {useReplicant} from "../../../use-replicant";
+import {Commentator} from "../../../../nodecg/replicants";
 
 type DisplayLabel = "name" | "twitter" | "twitch" | "nico";
 
@@ -10,33 +11,16 @@ export const SyncDisplayProvider = ({children}: {children: ReactNode}) => {
 	const [display, setDisplay] = useState<DisplayLabel>("name");
 
 	const currentRun = useReplicant("current-run");
-
-	const participantSocials = [
-		...(currentRun?.runners.map((runner) =>
-			[
-				runner.twitter ? "twitter" : null,
-				runner.twitch ? "twitch" : null,
-				runner.nico ? "nico" : null,
-			].filter((v): v is DisplayLabel => v !== null),
-		) ?? []),
-		...(currentRun?.commentators.map((commentator) =>
-			[
-				commentator?.twitter ? "twitter" : null,
-				commentator?.twitch ? "twitch" : null,
-				commentator?.nico ? "nico" : null,
-			].filter((v): v is DisplayLabel => v !== null),
+	const participants = [
+		...(currentRun?.runners ?? []),
+		...(currentRun?.commentators.filter(
+			(c): c is NonNullable<Commentator> => c !== null,
 		) ?? []),
 	];
 
-	const displayTwitter = participantSocials.some((socials) =>
-		socials.includes("twitter"),
-	);
-	const displayTwitch = participantSocials.some((socials) =>
-		socials.includes("twitch"),
-	);
-	const displayNico = participantSocials.some((socials) =>
-		socials.includes("nico"),
-	);
+	const displayTwitter = participants.some((p) => Boolean(p.twitter));
+	const displayTwitch = participants.some((p) => Boolean(p.twitch));
+	const displayNico = participants.some((p) => Boolean(p.nico));
 
 	useEffect(() => {
 		const tl = gsap.timeline({repeat: -1});

--- a/src/browser/graphics/components/nameplate/sync-display.tsx
+++ b/src/browser/graphics/components/nameplate/sync-display.tsx
@@ -1,7 +1,6 @@
 import gsap from "gsap";
 import {ReactNode, createContext, useEffect, useState} from "react";
 import {useReplicant} from "../../../use-replicant";
-import {Commentator} from "../../../../nodecg/replicants";
 
 type DisplayLabel = "name" | "twitter" | "twitch" | "nico";
 

--- a/src/browser/graphics/components/nameplate/sync-display.tsx
+++ b/src/browser/graphics/components/nameplate/sync-display.tsx
@@ -13,14 +13,12 @@ export const SyncDisplayProvider = ({children}: {children: ReactNode}) => {
 	const currentRun = useReplicant("current-run");
 	const participants = [
 		...(currentRun?.runners ?? []),
-		...(currentRun?.commentators.filter(
-			(c): c is NonNullable<Commentator> => c !== null,
-		) ?? []),
+		...(currentRun?.commentators ?? []),
 	];
 
-	const displayTwitter = participants.some((p) => Boolean(p.twitter));
-	const displayTwitch = participants.some((p) => Boolean(p.twitch));
-	const displayNico = participants.some((p) => Boolean(p.nico));
+	const displayTwitter = participants.some((p) => Boolean(p?.twitter));
+	const displayTwitch = participants.some((p) => Boolean(p?.twitch));
+	const displayNico = participants.some((p) => Boolean(p?.nico));
 
 	useEffect(() => {
 		const tl = gsap.timeline({repeat: -1});

--- a/src/browser/graphics/views/game.tsx
+++ b/src/browser/graphics/views/game.tsx
@@ -2,11 +2,16 @@ import "modern-normalize";
 import "../styles/adobe-fonts.js";
 
 import {render} from "../../render.js";
+import {SyncDisplayProvider} from "../components/nameplate/sync-display.js";
 
 const params = new URLSearchParams(location.search);
 const layout = params.get("layout") ?? "4x3-1";
 
 (async () => {
 	const {default: App} = await import(`./game-scene/${layout}.tsx`);
-	render(<App />);
+	render(
+		<SyncDisplayProvider>
+			<App />
+		</SyncDisplayProvider>,
+	);
 })();


### PR DESCRIPTION
ネームプレートごとに gsap のタイムラインが存在するため、 徐々に同期がズレて異なる情報が表示されるようになってしまっていました

- `SyncDisplayProvider` を用意して、どの情報を表示するかを graphics 内で統一した
- 副作用的に 名前 => 名前と表示されるときもフェードを挟まないようになった

