### PR TITLE
breakの楽曲ライセンス情報を指定した曲名の場合無視する

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -71,7 +71,12 @@
 			"additionalProperties": false,
 			"properties": {
 				"textPrefix": {"type": "string", "default": ""},
-				"textSuffix": {"type": "string", "default": ""}
+				"textSuffix": {"type": "string", "default": ""},
+				"removeMusicSuffix": {
+					"type": "array",
+					"items": {"type": "string"},
+					"default": []
+				}
 			}
 		},
 		"googleApiKey": {"type": "string"},

--- a/src/browser/graphics/components/music.tsx
+++ b/src/browser/graphics/components/music.tsx
@@ -7,9 +7,15 @@ import {ThinText} from "./lib/text";
 
 export const Music = () => {
 	const playingMusic = useReplicant("playing-music");
+	const isRemoveMusicSuffix =
+		nodecg.bundleConfig.music?.removeMusicSuffix?.some((music) =>
+			playingMusic?.includes(music),
+		);
 	const text = `${
 		nodecg.bundleConfig.music?.textPrefix ?? ""
-	} ${playingMusic} ${nodecg.bundleConfig.music?.textSuffix ?? ""}`;
+	} ${playingMusic} ${
+		!isRemoveMusicSuffix ? nodecg.bundleConfig.music?.textSuffix ?? "" : ""
+	}`;
 	const ref = useRef<HTMLDivElement>(null);
 	const [shownText, setShownText] = useState("");
 


### PR DESCRIPTION
- ライセンスを付与したくない曲をconfigで指定し、ライセンスを無視できるようにした

## サンプル
```
"music": {
  "textPrefix": "[うた]",
  "textSuffix": "music by 誰か",
  "removeMusicSuffix": ["Dapper", "Divertissement", "若林タカツグ"]
},
```
![image](https://github.com/user-attachments/assets/995d69a3-b2a5-4851-adab-5f8d29fe76b4)
![image](https://github.com/user-attachments/assets/06399935-428b-43bd-b9e2-1f012e7c88f0)
