### PR TITLE
Github Actionのビルドパターン追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,18 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
-
       - run: npm ci
       - run: npm test
       - run: npm run build


### PR DESCRIPTION
- Ubuntuでしか動いてなかったビルドテストをWindowsでも動かすようにした。
  - イベント中にビルド動かすのはWindows上なので、Windowsでビルド通るかどうかの検証は大事
- ビルドに使うNode.jsのパターンを増やしてみた（18.xはもう消してもいいかもしれない）