### PR TITLE
現在のゲーム・次のゲームをスケジュールの値に更新できるようにする

### DIFF
--- a/src/browser/dashboard/components/schedule/index.tsx
+++ b/src/browser/dashboard/components/schedule/index.tsx
@@ -11,6 +11,7 @@ import {ColoredButton} from "../lib/colored-button";
 import {EditRun} from "./edit";
 import {RunInfo} from "./run-info";
 import {Typeahead} from "./typeahead";
+import {green} from "@mui/material/colors";
 
 const Container = styled(BorderedBox)`
 	height: calc(100vh - 32px);
@@ -48,6 +49,18 @@ const moveNextRun = () => {
 
 const movePreviousRun = () => {
 	nodecg.sendMessage("previousRun");
+};
+
+const refreshCurrentRun = () => {
+	if (confirm("編集した内容は破棄されます。現在のゲームを更新しますか？")) {
+		nodecg.sendMessage("refreshRun", "current");
+	}
+};
+
+const refreshNextRun = () => {
+	if (confirm("編集した内容は破棄されます。次のゲームを更新しますか？")) {
+		nodecg.sendMessage("refreshRun", "next");
+	}
 };
 
 export const Schedule: FC = () => {
@@ -105,6 +118,12 @@ export const Schedule: FC = () => {
 					ButtonProps={{onClick: () => setEditting("next")}}
 				>
 					編集：次のゲーム
+				</ColoredButton>
+				<ColoredButton color={green} ButtonProps={{onClick: refreshCurrentRun}}>
+					現在のゲームを再読み込み
+				</ColoredButton>
+				<ColoredButton color={green} ButtonProps={{onClick: refreshNextRun}}>
+					次のゲームを再読み込み
 				</ColoredButton>
 			</EditControls>
 			{edittingRun && (

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -60,6 +60,16 @@ export default async (nodecg: NodeCG) => {
 		currentRunRep.value = clone(scheduleRep.value[currentIndex - 1]);
 	};
 
+	const refreshRun = (deck: "current" | "next") => {
+		const targetRep = deck === "current" ? currentRunRep : nextRunRep;
+		if (!targetRep.value) {
+			return;
+		}
+		const index = targetRep.value.index;
+		const freshRun = scheduleRep.value?.find((r) => r.index === index);
+		currentRunRep.value = clone(freshRun);
+	};
+
 	nodecg.listenFor("nextRun", (_, cb) => {
 		seekToNextRun();
 		if (cb && !cb.handled) {
@@ -101,6 +111,13 @@ export default async (nodecg: NodeCG) => {
 			if (cb && !cb.handled) {
 				cb(error instanceof Error ? error.message : "error");
 			}
+		}
+	});
+
+	nodecg.listenFor("refreshRun", (deck, cb) => {
+		refreshRun(deck);
+		if (cb && !cb.handled) {
+			cb(null);
 		}
 	});
 

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -67,7 +67,7 @@ export default async (nodecg: NodeCG) => {
 		}
 		const index = targetRep.value.index;
 		const freshRun = scheduleRep.value?.find((r) => r.index === index);
-		currentRunRep.value = clone(freshRun);
+		targetRep.value = clone(freshRun);
 	};
 
 	nodecg.listenFor("nextRun", (_, cb) => {

--- a/src/nodecg/messages.d.ts
+++ b/src/nodecg/messages.d.ts
@@ -29,6 +29,7 @@ export type MessageMap = {
 	nextRun: {};
 	previousRun: {};
 	modifyRun: {data: Run; error: string};
+	refreshRun: {data: "current" | "next"};
 	toggleCheckbox: {data: {runPk: number; checkPk: string; checked: boolean}};
 	resetChecklist: {};
 	"obs:connect": {};


### PR DESCRIPTION
バックアップ投入時や解説が直前に追加されたとき用（既存の操作がかなりハック寄りだったので、UIでできるようにした）

## UI

<img width="924" height="705" alt="image" src="https://github.com/user-attachments/assets/415b15bd-0c4f-47f3-ad23-20f43f0e0420" />
