### PR TITLE
登録済のファンアートURLを弾く、各要素のサイズ制限を追加

### DIFF
--- a/schemas/tweets-temp-images.json
+++ b/schemas/tweets-temp-images.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema",
+
+	"type": "array",
+	"items": {"type": "string"},
+	"default": []
+}

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -7,6 +7,7 @@ import {useReplicant} from "../../../use-replicant";
 const Container = styled.div``;
 
 const tweetsTempRep = nodecg.Replicant("tweets-temp");
+const tweetsTempImagesRep = nodecg.Replicant("tweets-temp-images");
 
 export const Twitter = () => {
 	const tweets = useReplicant("tweets-temp");
@@ -17,7 +18,16 @@ export const Twitter = () => {
 				<TweetAdd
 					onSubmit={(tweets, onSuccess) => {
 						if (tweetsTempRep.value && tweets.text && tweets.name) {
+							if (
+								tweetsTempImagesRep.value?.some(
+									(image) => image === tweets.image,
+								)
+							) {
+								alert("該当の画像URLは登録済です。");
+								return;
+							}
 							tweetsTempRep.value.push(tweets);
+							tweetsTempImagesRep.value?.push(tweets?.image ?? "");
 							onSuccess();
 						}
 					}}

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -19,15 +19,16 @@ export const Twitter = () => {
 					onSubmit={(tweets, onSuccess) => {
 						if (tweetsTempRep.value && tweets.text && tweets.name) {
 							if (
-								tweetsTempImagesRep.value?.some(
-									(image) => image === tweets.image,
-								)
+								tweets.image &&
+								tweetsTempImagesRep.value?.includes(tweets.image)
 							) {
 								alert("該当の画像URLは登録済です。");
 								return;
 							}
 							tweetsTempRep.value.push(tweets);
-							tweetsTempImagesRep.value?.push(tweets?.image ?? "");
+							if (tweets.image) {
+								tweetsTempImagesRep.value?.push(tweets.image);
+							}
 							onSuccess();
 						}
 					}}

--- a/src/browser/graphics/components/fan-art-tweet.tsx
+++ b/src/browser/graphics/components/fan-art-tweet.tsx
@@ -55,7 +55,17 @@ export const FanArtTweet = ({
 					width={30}
 					style={{margin: "0 10px"}}
 				></img>
-				<ThinText style={{fontSize: "20px"}}>{user}</ThinText>
+				<ThinText
+					style={{
+						fontSize: "20px",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+						maxWidth: "280px",
+					}}
+				>
+					{user}
+				</ThinText>
 			</div>
 			<ThinText
 				style={{
@@ -65,6 +75,12 @@ export const FanArtTweet = ({
 					wordBreak: "break-all",
 					gridRow: "2 / 3",
 					gridColumn: "1 / 2",
+					maxHeight: "280px",
+					textOverflow: "ellipsis",
+					overflow: "hidden",
+					display: "-webkit-box",
+					WebkitBoxOrient: "vertical",
+					WebkitLineClamp: 9, // 最大行数を指定
 				}}
 			>
 				{text}

--- a/src/nodecg/replicants.d.ts
+++ b/src/nodecg/replicants.d.ts
@@ -4,6 +4,7 @@ import {NextRun} from "./generated/next-run";
 import {Schedule} from "./generated/schedule";
 import {Tweets} from "./generated/tweets";
 import {TweetsTemp} from "./generated/tweets-temp";
+import {TweetsTempImages} from "./generated/tweets-temp-images";
 import {Timer} from "./generated/timer";
 import {Spotify} from "./generated/spotify";
 import {Spreadsheet} from "./generated/spreadsheet";
@@ -52,6 +53,7 @@ type ReplicantMap = {
 	timer: Timer;
 	tweets: Tweets;
 	"tweets-temp": TweetsTemp;
+	"tweets-temp-images": TweetsTempImages;
 	"obs-status": ObsStatus;
 	obs: Obs;
 	"obs-crop-inputs": ObsCropInputs;


### PR DESCRIPTION
- ファンアート画像URLを記録し、既に記録した画像URLを登録しようとすると弾くように
- ファンアートのユーザー名、本文のサイズに制限をかけた

キャッシュ全削除ボタンについてはよくわかんなかったので後回し(画像URLリストの削除？)