### PR TITLE
最終ゲームの「次へ」で空欄に遷移できるようにする (#768)

### DIFF
--- a/schemas/ending.json
+++ b/schemas/ending.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema",
+
+	"type": "boolean",
+	"default": false,
+	"description": "最終ゲームの次 (閉幕) に進み、ゲーム表示を消している状態か"
+}

--- a/src/browser/dashboard/components/schedule/index.tsx
+++ b/src/browser/dashboard/components/schedule/index.tsx
@@ -1,4 +1,4 @@
-import {pink, purple, green} from "@mui/material/colors";
+import {pink, purple, green, grey} from "@mui/material/colors";
 import ArrowBack from "@mui/icons-material/ArrowBack";
 import ArrowForward from "@mui/icons-material/ArrowForward";
 import {styled} from "@mui/material/styles";
@@ -39,6 +39,27 @@ const EditControls = styled("div")({
 	display: "grid",
 	gridTemplateColumns: "repeat(2, 1fr)",
 	gridGap: "16px",
+});
+
+// 閉幕表示中は右パネル全体を閉幕用表示に切り替える (最終ゲームの情報は出さない)。
+const EndingDisplay = styled("div")({
+	display: "grid",
+	placeContent: "center",
+	justifyItems: "center",
+	gap: "16px",
+	textAlign: "center",
+});
+
+// タイトルは左 (タイマー欄の「全ゲーム完了」) とフォントサイズを合わせる。
+const EndingTitle = styled("div")({
+	fontSize: "40px",
+	fontWeight: "bold",
+});
+
+// 補足は少し小さめのキャプション表示。
+const EndingHint = styled("div")({
+	fontSize: "14px",
+	color: grey[600],
 });
 
 const moveNextRun = () => {
@@ -101,26 +122,18 @@ export const Schedule: FC = () => {
 					次<ArrowForward />
 				</ColoredButton>
 			</SelectionContainer>
-			<RunInfoContainer>
-				{currentRun && <RunInfo run={currentRun} label='現在のゲーム' />}
-				<Divider />
-				{ending ? (
-					<div
-						style={{
-							alignSelf: "center",
-							fontSize: "18px",
-							fontWeight: "bold",
-							color: purple[700],
-						}}
-					>
-						閉幕表示中（次のゲームは非表示）
-						<br />
-						「前」で最後のゲームに戻ります
-					</div>
-				) : (
-					nextRun && <RunInfo run={nextRun} label='次のゲーム' />
-				)}
-			</RunInfoContainer>
+			{ending ? (
+				<EndingDisplay>
+					<EndingTitle>全ゲーム完了</EndingTitle>
+					<EndingHint>「前」で最終ゲームに戻る</EndingHint>
+				</EndingDisplay>
+			) : (
+				<RunInfoContainer>
+					{currentRun && <RunInfo run={currentRun} label='現在のゲーム' />}
+					<Divider />
+					{nextRun && <RunInfo run={nextRun} label='次のゲーム' />}
+				</RunInfoContainer>
+			)}
 			<EditControls>
 				<ColoredButton
 					color={pink}

--- a/src/browser/dashboard/components/schedule/index.tsx
+++ b/src/browser/dashboard/components/schedule/index.tsx
@@ -67,6 +67,7 @@ export const Schedule: FC = () => {
 	const [editting, setEditting] = useState<"current" | "next">();
 	const schedule = useReplicant("schedule");
 	const timer = useReplicant("timer");
+	const ending = useReplicant("ending");
 
 	if (!timer || !schedule) {
 		return null;
@@ -102,7 +103,22 @@ export const Schedule: FC = () => {
 			<RunInfoContainer>
 				{currentRun && <RunInfo run={currentRun} label='現在のゲーム' />}
 				<Divider />
-				{nextRun && <RunInfo run={nextRun} label='次のゲーム' />}
+				{ending ? (
+					<div
+						style={{
+							alignSelf: "center",
+							fontSize: "18px",
+							fontWeight: "bold",
+							color: purple[700],
+						}}
+					>
+						閉幕表示中（次のゲームは非表示）
+						<br />
+						「前」で最後のゲームに戻ります
+					</div>
+				) : (
+					nextRun && <RunInfo run={nextRun} label='次のゲーム' />
+				)}
 			</RunInfoContainer>
 			<EditControls>
 				<ColoredButton

--- a/src/browser/dashboard/components/schedule/index.tsx
+++ b/src/browser/dashboard/components/schedule/index.tsx
@@ -94,7 +94,8 @@ export const Schedule: FC = () => {
 					color={purple}
 					ButtonProps={{
 						onClick: moveNextRun,
-						disabled: disablePrevNextButtons,
+						// 閉幕表示中は最後のゲームより先が無いので「次」を無効化する。
+						disabled: disablePrevNextButtons || !!ending,
 					}}
 				>
 					次<ArrowForward />

--- a/src/browser/dashboard/components/timekeeper/index.tsx
+++ b/src/browser/dashboard/components/timekeeper/index.tsx
@@ -22,6 +22,16 @@ const Container = styled(BorderedBox)({
 	alignItems: "center",
 });
 
+// 全ゲーム完了 (閉幕) 状態でタイマー欄に表示する文言。黒枠は Container 側で維持する。
+const CompletedNotice = styled("div")({
+	gridColumn: "1 / -1",
+	gridRow: "1 / -1",
+	display: "grid",
+	placeItems: "center",
+	fontSize: "40px",
+	fontWeight: "bold",
+});
+
 const Timer = styled("div")({
 	gridArea: "timer",
 	padding: "0 16px",
@@ -70,6 +80,7 @@ export const Timekeeper: FC = () => {
 	const timer = useTimer();
 	const currentRun = useReplicant("current-run");
 	const checklist = useReplicant("checklist");
+	const ending = useReplicant("ending");
 
 	const [isModalOpened, setIsModalOpened] = useState<boolean>(false);
 
@@ -83,6 +94,16 @@ export const Timekeeper: FC = () => {
 			})),
 		);
 	}, [currentRun]);
+
+	// 全ゲーム完了 (閉幕) 状態。タイマー欄は黒枠を残したまま「全ゲーム完了」を表示し、
+	// 真っ白で「表示されていない (バグ?)」と見えないようにする (#768)。
+	if (ending) {
+		return (
+			<Container>
+				<CompletedNotice>全ゲーム完了</CompletedNotice>
+			</Container>
+		);
+	}
 
 	if (!currentRun || !checklist || !timer) {
 		return null;

--- a/src/browser/graphics/components/lib/hooks.ts
+++ b/src/browser/graphics/components/lib/hooks.ts
@@ -16,6 +16,11 @@ export const useTimer = () => {
 	return timer;
 };
 
+// 最終ゲームの次 (閉幕) に進み、ゲーム表示を消している状態か (#768)。
+export const useEnding = () => {
+	return useReplicant("ending");
+};
+
 export const useAudioActive = (
 	kind: "runners" | "commentators",
 	index: number,

--- a/src/browser/graphics/views/break.tsx
+++ b/src/browser/graphics/views/break.tsx
@@ -5,7 +5,7 @@ import {BoldText, ThinText} from "../components/lib/text";
 import nextGameBar from "../images/next_line.svg";
 import nextGameSpacer from "../images/next_spacer.svg";
 import setupShade from "../images/setup_shade.svg";
-import {useCurrentRun, useSchedule} from "../components/lib/hooks";
+import {useCurrentRun, useEnding, useSchedule} from "../components/lib/hooks";
 import {Run} from "../../../nodecg/replicants";
 import moment from "moment";
 import {Fragment, useCallback, useRef} from "react";
@@ -23,8 +23,10 @@ const Spacer = () => <img src={nextGameSpacer} width={50} height={60}></img>;
 const Upcoming = () => {
 	const currentRun = useCurrentRun();
 	const schedule = useSchedule();
+	const ending = useEnding();
 
-	if (!currentRun || !schedule) {
+	// 閉幕表示中 (最後のゲームの次) は「次のゲーム」表示をまるごと消す (#768)。
+	if (!currentRun || !schedule || ending) {
 		return null;
 	}
 

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -36,6 +36,11 @@ export default async (nodecg: NodeCG) => {
 			return;
 		}
 		if (currentIndex >= scheduleRep.value.length - 1) {
+			// 最後のゲームで「次へ」→ 空欄 (閉幕の挨拶用) に遷移する。
+			// current-run を null にすると、break グラフィクスの「次のゲーム」表示は
+			// まるごと非表示になる。「前へ」で最後のゲームに戻せる (seekToPreviousRun)。
+			currentRunRep.value = null;
+			nextRunRep.value = null;
 			return;
 		}
 		currentRunRep.value = clone(nextRunRep.value);
@@ -63,7 +68,12 @@ export default async (nodecg: NodeCG) => {
 		if (timerRep.value?.timerState === "Running") {
 			return;
 		}
-		if (!currentRunRep.value || !scheduleRep.value) {
+		if (!scheduleRep.value) {
+			return;
+		}
+		// 空欄 (最後のゲームの次) から「前へ」→ 最後のゲームに戻す。
+		if (!currentRunRep.value) {
+			updateCurrentRun(scheduleRep.value.length - 1);
 			return;
 		}
 		const currentIndex = currentRunRep.value.index;

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -8,6 +8,11 @@ export default async (nodecg: NodeCG) => {
 	const timerRep = nodecg.Replicant("timer");
 	const audioAssignmentRep = nodecg.Replicant("audio-assignment");
 
+	// 最後のゲームの次 (意図的な空欄) に遷移したかどうか。true の間はスケジュール
+	// 更新で空欄を自動復帰させない (#768)。データ未投入やレプリカント不整合による
+	// 「意図しない空」は false のままなので、引き続き自動復帰の対象になる。
+	let isPastScheduleEnd = false;
+
 	const updateCurrentRun = (index: number) => {
 		if (timerRep.value?.timerState === "Running") {
 			return;
@@ -21,6 +26,8 @@ export default async (nodecg: NodeCG) => {
 		}
 		currentRunRep.value = clone(newCurrentRun);
 		nextRunRep.value = clone(scheduleRep.value[index + 1]);
+		// 実在の run をセットした (空欄から復帰する経路はここを通る)。
+		isPastScheduleEnd = false;
 	};
 
 	const seekToNextRun = () => {
@@ -41,6 +48,7 @@ export default async (nodecg: NodeCG) => {
 			// まるごと非表示になる。「前へ」で最後のゲームに戻せる (seekToPreviousRun)。
 			currentRunRep.value = null;
 			nextRunRep.value = null;
+			isPastScheduleEnd = true;
 			return;
 		}
 		currentRunRep.value = clone(nextRunRep.value);
@@ -149,27 +157,20 @@ export default async (nodecg: NodeCG) => {
 		}
 	});
 
-	// 初回のみ、空の current-run をスケジュール先頭のゲームで初期化する。
-	// 一度初期化 (もしくは既に設定済み) された後は、スケジュールの更新
-	// (tracker からの定期反映など) で current-run を上書きしない。これにより、
-	// 最後のゲームの後に「次へ」で空欄にした状態が、スケジュール更新のたびに
-	// 勝手に先頭ゲームへ戻ってしまうのを防ぐ (#768)。
-	let hasInitializedCurrentRun = false;
+	// 空の current-run を防ぐ (データ未投入やレプリカント不整合からの自動復帰)。
+	// スケジュール更新のたびに評価し、空なら先頭ゲームへ復帰させる。
+	// ただし、最後のゲームの次の「意図的な空欄」(#768) は維持する。
 	scheduleRep.on("change", (newVal) => {
-		if (hasInitializedCurrentRun) {
+		if (isPastScheduleEnd) {
 			return;
 		}
 		const isCurrentRunEmpty = !currentRunRep.value || !currentRunRep.value.pk;
-		if (!isCurrentRunEmpty) {
-			// 既に current-run が設定済み (永続値や操作者の選択) なら初期化不要。
-			hasInitializedCurrentRun = true;
-			return;
-		}
-		const currentRun = newVal[0];
-		if (currentRun) {
-			currentRunRep.value = clone(currentRun);
-			nextRunRep.value = clone(newVal[1]);
-			hasInitializedCurrentRun = true;
+		if (isCurrentRunEmpty) {
+			const currentRun = newVal[0];
+			if (currentRun) {
+				currentRunRep.value = clone(currentRun);
+				nextRunRep.value = clone(newVal[1]);
+			}
 		}
 	});
 };

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -149,15 +149,27 @@ export default async (nodecg: NodeCG) => {
 		}
 	});
 
-	// Prevent empty current run
+	// 初回のみ、空の current-run をスケジュール先頭のゲームで初期化する。
+	// 一度初期化 (もしくは既に設定済み) された後は、スケジュールの更新
+	// (tracker からの定期反映など) で current-run を上書きしない。これにより、
+	// 最後のゲームの後に「次へ」で空欄にした状態が、スケジュール更新のたびに
+	// 勝手に先頭ゲームへ戻ってしまうのを防ぐ (#768)。
+	let hasInitializedCurrentRun = false;
 	scheduleRep.on("change", (newVal) => {
+		if (hasInitializedCurrentRun) {
+			return;
+		}
 		const isCurrentRunEmpty = !currentRunRep.value || !currentRunRep.value.pk;
-		if (isCurrentRunEmpty) {
-			const currentRun = newVal[0];
-			if (currentRun) {
-				currentRunRep.value = clone(currentRun);
-				nextRunRep.value = clone(newVal[1]);
-			}
+		if (!isCurrentRunEmpty) {
+			// 既に current-run が設定済み (永続値や操作者の選択) なら初期化不要。
+			hasInitializedCurrentRun = true;
+			return;
+		}
+		const currentRun = newVal[0];
+		if (currentRun) {
+			currentRunRep.value = clone(currentRun);
+			nextRunRep.value = clone(newVal[1]);
+			hasInitializedCurrentRun = true;
 		}
 	});
 };

--- a/src/extension/schedule.ts
+++ b/src/extension/schedule.ts
@@ -7,11 +7,10 @@ export default async (nodecg: NodeCG) => {
 	const nextRunRep = nodecg.Replicant("next-run");
 	const timerRep = nodecg.Replicant("timer");
 	const audioAssignmentRep = nodecg.Replicant("audio-assignment");
-
-	// 最後のゲームの次 (意図的な空欄) に遷移したかどうか。true の間はスケジュール
-	// 更新で空欄を自動復帰させない (#768)。データ未投入やレプリカント不整合による
-	// 「意図しない空」は false のままなので、引き続き自動復帰の対象になる。
-	let isPastScheduleEnd = false;
+	// 最後のゲームの次 (閉幕) に進んだ状態。current-run は最後のゲームのまま保持し、
+	// このフラグでグラフィクスのゲーム表示を消す (#768)。current-run / schedule の
+	// 既存ロジック (空の自動復帰など) には手を入れないための専用レプリカント。
+	const endingRep = nodecg.Replicant("ending");
 
 	const updateCurrentRun = (index: number) => {
 		if (timerRep.value?.timerState === "Running") {
@@ -26,8 +25,8 @@ export default async (nodecg: NodeCG) => {
 		}
 		currentRunRep.value = clone(newCurrentRun);
 		nextRunRep.value = clone(scheduleRep.value[index + 1]);
-		// 実在の run をセットした (空欄から復帰する経路はここを通る)。
-		isPastScheduleEnd = false;
+		// 実在の run を選び直したので閉幕表示は解除する。
+		endingRep.value = false;
 	};
 
 	const seekToNextRun = () => {
@@ -43,12 +42,10 @@ export default async (nodecg: NodeCG) => {
 			return;
 		}
 		if (currentIndex >= scheduleRep.value.length - 1) {
-			// 最後のゲームで「次へ」→ 空欄 (閉幕の挨拶用) に遷移する。
-			// current-run を null にすると、break グラフィクスの「次のゲーム」表示は
-			// まるごと非表示になる。「前へ」で最後のゲームに戻せる (seekToPreviousRun)。
-			currentRunRep.value = null;
-			nextRunRep.value = null;
-			isPastScheduleEnd = true;
+			// 最後のゲームで「次へ」→ 閉幕表示へ。current-run は最後のゲームのまま
+			// 保持し、ending フラグでグラフィクスの「次のゲーム」表示を消す。
+			// 「前へ」で ending を解除すれば元の表示に戻る (seekToPreviousRun)。
+			endingRep.value = true;
 			return;
 		}
 		currentRunRep.value = clone(nextRunRep.value);
@@ -76,12 +73,12 @@ export default async (nodecg: NodeCG) => {
 		if (timerRep.value?.timerState === "Running") {
 			return;
 		}
-		if (!scheduleRep.value) {
+		if (!currentRunRep.value || !scheduleRep.value) {
 			return;
 		}
-		// 空欄 (最後のゲームの次) から「前へ」→ 最後のゲームに戻す。
-		if (!currentRunRep.value) {
-			updateCurrentRun(scheduleRep.value.length - 1);
+		// 閉幕表示中なら、「前へ」で表示を元 (最後のゲーム) に戻すだけ。
+		if (endingRep.value) {
+			endingRep.value = false;
 			return;
 		}
 		const currentIndex = currentRunRep.value.index;
@@ -157,13 +154,8 @@ export default async (nodecg: NodeCG) => {
 		}
 	});
 
-	// 空の current-run を防ぐ (データ未投入やレプリカント不整合からの自動復帰)。
-	// スケジュール更新のたびに評価し、空なら先頭ゲームへ復帰させる。
-	// ただし、最後のゲームの次の「意図的な空欄」(#768) は維持する。
+	// Prevent empty current run
 	scheduleRep.on("change", (newVal) => {
-		if (isPastScheduleEnd) {
-			return;
-		}
 		const isCurrentRunEmpty = !currentRunRep.value || !currentRunRep.value.pk;
 		if (isCurrentRunEmpty) {
 			const currentRun = newVal[0];

--- a/src/nodecg/replicants.d.ts
+++ b/src/nodecg/replicants.d.ts
@@ -30,6 +30,7 @@ import {AudioActive} from "./generated/audio-active";
 import {AudioAssignment} from "./generated/audio-assignment";
 import {AudioConfig} from "./generated/audio-config";
 import {AudioStatus} from "./generated/audio-status";
+import {Ending} from "./generated/ending";
 
 type Run = NonNullable<CurrentRun>;
 type Runner = Run["runners"][number];
@@ -87,6 +88,7 @@ type ReplicantMap = {
 	"audio-assignment": AudioAssignment;
 	"audio-config": AudioConfig;
 	"audio-status": AudioStatus;
+	ending: Ending;
 };
 
 export type {


### PR DESCRIPTION
## 概要

- [#768](https://github.com/RTAinJapan/rtainjapan-layouts/issues/768) の対応。
- これまでは、閉幕の挨拶に移る際に最後のゲームを表示しないようにするため、次ボタンを押して空にしたいが、仕様上それができず、UI非表示のOBSシーンで対応していた。
- 今回の対応で、最終ゲームが完了したら次ボタンを押すことでいい感じの表示になるようになった。

## 変更点

- 閉幕表示用のレプリカントを追加
- current-runを空にするだけじゃダメなのか、という疑問は出ると思うが以下の理由でそうしてる。
  - schedule定期更新処理の際に、current-runが空の場合はscheduleの最初の要素を入れる処理とぶつかってしまうため。
  - じゃその処理を消すかというと、分岐が複雑になったり、レプリカント不整合のときに救えない障害ケースが出てくる可能性がある。
  - なのでなるべくそこはいじらないことにした。

<img width="1919" height="878" alt="image" src="https://github.com/user-attachments/assets/2ed45b9c-44e3-447e-97d3-d67edec9fcb3" />

<img width="862" height="500" alt="image" src="https://github.com/user-attachments/assets/7878e2ce-b90f-4851-89ec-4d32d77fad9a" />



