### PR TITLE
ファンアートを一時保存して「まとめて表示」できるようにする (#758)

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -10,7 +10,8 @@
 			"type": "object",
 			"properties": {
 				"address": {"type": "string"},
-				"password": {"type": "string"}
+				"password": {"type": "string"},
+				"setupSceneName": {"type": "string", "default": "Setup"}
 			},
 			"additionalProperties": false,
 			"required": ["address", "password"]

--- a/configschema.json
+++ b/configschema.json
@@ -11,7 +11,8 @@
 			"properties": {
 				"address": {"type": "string"},
 				"password": {"type": "string"},
-				"setupSceneName": {"type": "string", "default": "Setup"}
+				"setupSceneName": {"type": "string", "default": "Setup"},
+				"autoRecord": {"type": "boolean", "default": false}
 			},
 			"additionalProperties": false,
 			"required": ["address", "password"]

--- a/schemas/obs-current-scene.json
+++ b/schemas/obs-current-scene.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema",
+
+	"type": "string",
+	"default": "",
+	"description": "OBSのプログラム側に現在表示しているシーン名"
+}

--- a/schemas/tweets-temp.json
+++ b/schemas/tweets-temp.json
@@ -9,7 +9,8 @@
 			"name": {"type": "string"},
 			"userId": {"type": "string"},
 			"image": {"type": "string"},
-			"service": {"type": "string"}
+			"service": {"type": "string"},
+			"queued": {"type": "boolean", "default": false}
 		},
 		"additionalProperties": false,
 		"required": ["text", "name", "userId", "service"]

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -21,7 +21,9 @@ export const Twitter = () => {
 	const playing = useReplicant("tweet-queue-playing");
 
 	const queuedCount = tweets?.filter((tweet) => tweet.queued).length ?? 0;
-	const isOnSetup = currentScene === setupSceneName;
+	// シーンが判明していて Setup 以外のときだけ開始をブロックする。
+	// シーン不明 (OBS未接続など) のときは制約を緩めて押せるようにする。
+	const sceneBlocked = Boolean(currentScene) && currentScene !== setupSceneName;
 	const isPlaying = playing === true;
 
 	return (
@@ -48,7 +50,7 @@ export const Twitter = () => {
 				) : (
 					<Button
 						variant='contained'
-						disabled={queuedCount === 0 || !isOnSetup}
+						disabled={queuedCount === 0 || sceneBlocked}
 						onClick={() => {
 							nodecg.sendMessage("startTweetQueue");
 						}}

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -1,5 +1,6 @@
 import {styled} from "@mui/material/styles";
 import List from "@mui/material/List";
+import Button from "@mui/material/Button";
 import {TweetAdd} from "./tweet-add";
 import {TweetItem} from "./tweet-item";
 import {useReplicant} from "../../../use-replicant";
@@ -12,8 +13,29 @@ const tweetsTempImagesRep = nodecg.Replicant("tweets-temp-images");
 export const Twitter = () => {
 	const tweets = useReplicant("tweets-temp");
 
+	const queuedCount = tweets?.filter((tweet) => tweet.queued).length ?? 0;
+
 	return (
 		<Container>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: "12px",
+					padding: "8px 16px",
+				}}
+			>
+				<Button
+					variant='contained'
+					disabled={queuedCount === 0}
+					onClick={() => {
+						nodecg.sendMessage("startTweetQueue");
+					}}
+				>
+					まとめて表示
+				</Button>
+				<span>キュー: {queuedCount}件</span>
+			</div>
 			<List>
 				<TweetAdd
 					onSubmit={(tweets, onSuccess) => {
@@ -43,33 +65,19 @@ export const Twitter = () => {
 					<TweetItem
 						key={index}
 						tweet={tweet}
-						onSubmit={(tweet, onSuccess) => {
+						onToggleQueue={() => {
 							if (tweetsTempRep.value) {
-								tweetsTempRep.value = [
-									...tweets.slice(0, index),
-									...tweets.slice(index + 1),
-								];
-								nodecg.sendMessage("showTweet", tweet);
-								onSuccess();
+								tweetsTempRep.value = tweets.map((t, i) =>
+									i === index ? {...t, queued: !t.queued} : t,
+								);
 							}
 						}}
-						onSubmitFanArt={(tweet, onSuccess) => {
+						onDelete={() => {
 							if (tweetsTempRep.value) {
 								tweetsTempRep.value = [
 									...tweets.slice(0, index),
 									...tweets.slice(index + 1),
 								];
-								nodecg.sendMessage("showFanArtTweet", tweet);
-								onSuccess();
-							}
-						}}
-						onDelete={(onSuccess) => {
-							if (tweetsTempRep.value) {
-								tweetsTempRep.value = [
-									...tweets.slice(0, index),
-									...tweets.slice(index + 1),
-								];
-								onSuccess();
 							}
 						}}
 					/>

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -12,6 +12,9 @@ const tweetsTempImagesRep = nodecg.Replicant("tweets-temp-images");
 
 const setupSceneName = nodecg.bundleConfig.obs?.setupSceneName ?? "Setup";
 
+// リストが伸び続けないように、ツイート一覧だけをこの高さ内でスクロールさせる。
+const LIST_MAX_HEIGHT = 500;
+
 export const Twitter = () => {
 	const tweets = useReplicant("tweets-temp");
 	const currentScene = useReplicant("obs-current-scene");
@@ -23,6 +26,7 @@ export const Twitter = () => {
 
 	return (
 		<Container>
+			{/* スクロール対象外: 表示開始/停止ボタン */}
 			<div
 				style={{
 					display: "flex",
@@ -54,7 +58,8 @@ export const Twitter = () => {
 				)}
 				<span>キュー: {queuedCount}件</span>
 			</div>
-			<List>
+			{/* スクロール対象外: ツイート登録フォーム */}
+			<List disablePadding>
 				<TweetAdd
 					onSubmit={(tweets, onSuccess) => {
 						if (
@@ -79,6 +84,15 @@ export const Twitter = () => {
 						}
 					}}
 				/>
+			</List>
+			{/* スクロール対象: ツイート一覧 */}
+			<List
+				style={{
+					maxHeight: LIST_MAX_HEIGHT,
+					overflowY: "auto",
+					borderTop: "1px solid rgba(0, 0, 0, 0.12)",
+				}}
+			>
 				{tweets?.map((tweet, index) => (
 					<TweetItem
 						key={index}

--- a/src/browser/dashboard/components/twitter/index.tsx
+++ b/src/browser/dashboard/components/twitter/index.tsx
@@ -10,10 +10,16 @@ const Container = styled("div")({});
 const tweetsTempRep = nodecg.Replicant("tweets-temp");
 const tweetsTempImagesRep = nodecg.Replicant("tweets-temp-images");
 
+const setupSceneName = nodecg.bundleConfig.obs?.setupSceneName ?? "Setup";
+
 export const Twitter = () => {
 	const tweets = useReplicant("tweets-temp");
+	const currentScene = useReplicant("obs-current-scene");
+	const playing = useReplicant("tweet-queue-playing");
 
 	const queuedCount = tweets?.filter((tweet) => tweet.queued).length ?? 0;
+	const isOnSetup = currentScene === setupSceneName;
+	const isPlaying = playing === true;
 
 	return (
 		<Container>
@@ -25,15 +31,27 @@ export const Twitter = () => {
 					padding: "8px 16px",
 				}}
 			>
-				<Button
-					variant='contained'
-					disabled={queuedCount === 0}
-					onClick={() => {
-						nodecg.sendMessage("startTweetQueue");
-					}}
-				>
-					まとめて表示
-				</Button>
+				{isPlaying ? (
+					<Button
+						variant='contained'
+						color='error'
+						onClick={() => {
+							nodecg.sendMessage("stopTweetQueue");
+						}}
+					>
+						表示停止
+					</Button>
+				) : (
+					<Button
+						variant='contained'
+						disabled={queuedCount === 0 || !isOnSetup}
+						onClick={() => {
+							nodecg.sendMessage("startTweetQueue");
+						}}
+					>
+						表示開始
+					</Button>
+				)}
 				<span>キュー: {queuedCount}件</span>
 			</div>
 			<List>

--- a/src/browser/dashboard/components/twitter/tweet-item.tsx
+++ b/src/browser/dashboard/components/twitter/tweet-item.tsx
@@ -3,7 +3,8 @@ import Tooltip from "@mui/material/Tooltip";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
-import CheckIcon from "@mui/icons-material/Check";
+import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd";
+import PlaylistAddCheckIcon from "@mui/icons-material/PlaylistAddCheck";
 import DeleteIcon from "@mui/icons-material/Delete";
 import {useEffect, useState} from "react";
 import {TweetsTemp} from "../../../../nodecg/generated/tweets-temp";
@@ -12,9 +13,8 @@ type Tweet = TweetsTemp[number];
 
 type Props = {
 	tweet: Tweet;
-	onSubmit: (tweet: Tweet, onSuccess: () => void) => void;
-	onSubmitFanArt: (tweet: Tweet, onSuccess: () => void) => void;
-	onDelete: (onSuccess: () => void) => void;
+	onToggleQueue: () => void;
+	onDelete: () => void;
 };
 
 type ButtonProps = Pick<IconButtonProps, "onClick">;
@@ -29,11 +29,17 @@ const DeleteButton = (props: ButtonProps) => {
 	);
 };
 
-const SubmitButton = (props: ButtonProps) => {
+const QueueButton = ({queued, ...props}: ButtonProps & {queued: boolean}) => {
 	return (
-		<Tooltip title='ツイート表示/ファンアート表示を実行'>
-			<IconButton {...props}>
-				<CheckIcon />
+		<Tooltip
+			title={
+				queued
+					? "「まとめて表示」のキューから外す"
+					: "「まとめて表示」のキューに追加"
+			}
+		>
+			<IconButton {...props} color={queued ? "primary" : "default"}>
+				{queued ? <PlaylistAddCheckIcon /> : <PlaylistAddIcon />}
 			</IconButton>
 		</Tooltip>
 	);
@@ -41,8 +47,7 @@ const SubmitButton = (props: ButtonProps) => {
 
 export const TweetItem = ({
 	tweet: propTweet,
-	onSubmit,
-	onSubmitFanArt,
+	onToggleQueue,
 	onDelete,
 }: Props) => {
 	const [tweet, setTweet] = useState<Tweet>(propTweet);
@@ -55,17 +60,16 @@ export const TweetItem = ({
 		<ListItem
 			secondaryAction={
 				<>
-					<SubmitButton
+					<QueueButton
+						queued={Boolean(tweet.queued)}
 						onClick={() => {
-							tweet.image
-								? onSubmitFanArt(tweet, () => {})
-								: onSubmit(tweet, () => {});
+							onToggleQueue();
 						}}
 					/>
 					/
 					<DeleteButton
 						onClick={() => {
-							onDelete(() => {});
+							onDelete();
 						}}
 					/>
 				</>

--- a/src/browser/dashboard/components/twitter/tweet-item.tsx
+++ b/src/browser/dashboard/components/twitter/tweet-item.tsx
@@ -31,13 +31,7 @@ const DeleteButton = (props: ButtonProps) => {
 
 const QueueButton = ({queued, ...props}: ButtonProps & {queued: boolean}) => {
 	return (
-		<Tooltip
-			title={
-				queued
-					? "「まとめて表示」のキューから外す"
-					: "「まとめて表示」のキューに追加"
-			}
-		>
+		<Tooltip title={queued ? "キューから外す" : "キューに追加"}>
 			<IconButton {...props} color={queued ? "primary" : "default"}>
 				{queued ? <PlaylistAddCheckIcon /> : <PlaylistAddIcon />}
 			</IconButton>

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -4,6 +4,7 @@ import {timekeeping} from "./timekeeping";
 import {NodeCG} from "./nodecg";
 import {twitch} from "./twitch";
 import {setupObs} from "./obs";
+import {setupTweetQueue} from "./tweet-queue";
 import {tracker} from "./tracker";
 import {music} from "./music";
 import {wing} from "./wing";
@@ -15,6 +16,7 @@ export default (nodecg: NodeCG) => {
 	timekeeping(nodecg);
 	twitch(nodecg);
 	setupObs(nodecg);
+	setupTweetQueue(nodecg);
 	tracker(nodecg);
 	wing(nodecg);
 

--- a/src/extension/obs.ts
+++ b/src/extension/obs.ts
@@ -8,6 +8,7 @@ export const setupObs = (nodecg: NodeCG) => {
 	const {obs: obsConfig} = nodecg.bundleConfig;
 	const logger = new nodecg.Logger("obs");
 	const obsStatus = nodecg.Replicant("obs-status");
+	const currentSceneRep = nodecg.Replicant("obs-current-scene");
 
 	if (!obsConfig) {
 		logger.warn("OBS setting is empty");
@@ -22,7 +23,8 @@ export const setupObs = (nodecg: NodeCG) => {
 		attemptingToConnect = true;
 		try {
 			await obs.connect(obsConfig.address, obsConfig.password, {
-				eventSubscriptions: EventSubscription.Outputs,
+				eventSubscriptions:
+					EventSubscription.Outputs | EventSubscription.Scenes,
 			});
 		} catch (error: unknown) {
 			if (emitError) {
@@ -61,6 +63,15 @@ export const setupObs = (nodecg: NodeCG) => {
 		if (!outputActive) {
 			await startRecording();
 		}
+		try {
+			const {sceneName} = await obs.call("GetCurrentProgramScene");
+			currentSceneRep.value = sceneName;
+		} catch (error: unknown) {
+			logger.error("Failed to get current program scene:", error);
+		}
+	});
+	obs.on("CurrentProgramSceneChanged", (data) => {
+		currentSceneRep.value = data.sceneName;
 	});
 	obs.on("RecordStateChanged", (data) => {
 		if (data.outputState === "OBS_WEBSOCKET_OUTPUT_STOPPED") {
@@ -68,6 +79,8 @@ export const setupObs = (nodecg: NodeCG) => {
 		}
 	});
 	obs.on("ConnectionClosed", () => {
+		// 切断中はプログラムシーンが不明なので空にする (Setup と誤判定しないため)。
+		currentSceneRep.value = "";
 		if (obsStatus.value?.connected) {
 			logger.info(`Disconnected`);
 		}

--- a/src/extension/obs.ts
+++ b/src/extension/obs.ts
@@ -14,6 +14,10 @@ export const setupObs = (nodecg: NodeCG) => {
 		return;
 	}
 
+	// 自動録画 (接続時に録画開始 / 録画停止時に再開 / nextRun で停止) を使うか。
+	// 既定はオフ。使う場合は config の obs.autoRecord を true にする。
+	const autoRecord = obsConfig.autoRecord ?? false;
+
 	let connected = false;
 	let attemptingToConnect = false;
 	const connect = async (emitError = true) => {
@@ -52,7 +56,9 @@ export const setupObs = (nodecg: NodeCG) => {
 	};
 
 	nodecg.listenFor("nextRun", () => {
-		void stopRecording();
+		if (autoRecord) {
+			void stopRecording();
+		}
 	});
 
 	obs.on("ConnectionOpened", () => {
@@ -60,9 +66,11 @@ export const setupObs = (nodecg: NodeCG) => {
 	});
 	obs.on("Identified", async () => {
 		connected = true;
-		const {outputActive} = await obs.call("GetRecordStatus");
-		if (!outputActive) {
-			await startRecording();
+		if (autoRecord) {
+			const {outputActive} = await obs.call("GetRecordStatus");
+			if (!outputActive) {
+				await startRecording();
+			}
 		}
 		try {
 			const {sceneName} = await obs.call("GetCurrentProgramScene");
@@ -75,7 +83,7 @@ export const setupObs = (nodecg: NodeCG) => {
 		currentSceneRep.value = data.sceneName;
 	});
 	obs.on("RecordStateChanged", (data) => {
-		if (data.outputState === "OBS_WEBSOCKET_OUTPUT_STOPPED") {
+		if (autoRecord && data.outputState === "OBS_WEBSOCKET_OUTPUT_STOPPED") {
 			void startRecording();
 		}
 	});

--- a/src/extension/obs.ts
+++ b/src/extension/obs.ts
@@ -7,7 +7,6 @@ const obs = new OBSWebSocket();
 export const setupObs = (nodecg: NodeCG) => {
 	const {obs: obsConfig} = nodecg.bundleConfig;
 	const logger = new nodecg.Logger("obs");
-	const obsStatus = nodecg.Replicant("obs-status");
 	const currentSceneRep = nodecg.Replicant("obs-current-scene");
 
 	if (!obsConfig) {
@@ -15,9 +14,10 @@ export const setupObs = (nodecg: NodeCG) => {
 		return;
 	}
 
+	let connected = false;
 	let attemptingToConnect = false;
 	const connect = async (emitError = true) => {
-		if (attemptingToConnect) {
+		if (attemptingToConnect || connected) {
 			return;
 		}
 		attemptingToConnect = true;
@@ -59,6 +59,7 @@ export const setupObs = (nodecg: NodeCG) => {
 		logger.info(`Connected: ${obsConfig.address}`);
 	});
 	obs.on("Identified", async () => {
+		connected = true;
 		const {outputActive} = await obs.call("GetRecordStatus");
 		if (!outputActive) {
 			await startRecording();
@@ -79,17 +80,20 @@ export const setupObs = (nodecg: NodeCG) => {
 		}
 	});
 	obs.on("ConnectionClosed", () => {
-		// 切断中はプログラムシーンが不明なので空にする (Setup と誤判定しないため)。
-		currentSceneRep.value = "";
-		if (obsStatus.value?.connected) {
+		if (connected) {
 			logger.info(`Disconnected`);
 		}
+		connected = false;
+		// 切断中はプログラムシーンが不明なので空にする (Setup と誤判定しないため)。
+		currentSceneRep.value = "";
 	});
 
 	void connect();
 
+	// 接続が切れているときだけ再接続を試みる。
+	// (接続済みなのに再接続するとシーン追跡が不安定になり、ログも溢れる)
 	setInterval(() => {
-		if (!obsStatus.value?.connected) {
+		if (!connected) {
 			void connect(false);
 		}
 	}, 1000);

--- a/src/extension/tweet-queue.ts
+++ b/src/extension/tweet-queue.ts
@@ -10,26 +10,31 @@ export const setupTweetQueue = (nodecg: NodeCG) => {
 	const logger = new nodecg.Logger("tweet-queue");
 	const tweetsTempRep = nodecg.Replicant("tweets-temp");
 	const currentSceneRep = nodecg.Replicant("obs-current-scene");
+	// まとめて表示の処理中かどうか。ダッシュボードやStream Deckのボタン表示用。
+	const playingRep = nodecg.Replicant("tweet-queue-playing");
 
 	const setupSceneName =
 		nodecg.bundleConfig.obs?.setupSceneName ?? DEFAULT_SETUP_SCENE_NAME;
 
-	let playing = false;
 	let timer: NodeJS.Timeout | undefined;
+
+	const isPlaying = () => playingRep.value === true;
 
 	const stop = () => {
 		if (timer) {
 			clearTimeout(timer);
 			timer = undefined;
 		}
-		playing = false;
+		// 追加のキュー消費を止めるだけ。表示中のファンアートは規定時間まで残る
+		// (グラフィック側のアニメーションが独立して完了するため)。
+		playingRep.value = false;
 	};
 
 	// OBSのプログラム側がSetupシーンを表示しているかどうか。
 	const isOnSetupScene = () => currentSceneRep.value === setupSceneName;
 
 	const consumeNext = () => {
-		if (!playing) {
+		if (!isPlaying()) {
 			return;
 		}
 		// Setup以外のシーンに切り替わっていたら表示処理を停止する。
@@ -62,31 +67,44 @@ export const setupTweetQueue = (nodecg: NodeCG) => {
 		timer = setTimeout(consumeNext, DISPLAY_INTERVAL_MS);
 	};
 
+	// 「表示開始」。ダッシュボード/Stream Deck 共通の入口。
 	nodecg.listenFor("startTweetQueue", () => {
-		if (playing) {
+		if (isPlaying()) {
 			return;
 		}
 		// Setupを表示しているときのみキューの消化を開始する。
 		if (!isOnSetupScene()) {
 			logger.warn(
-				`「まとめて表示」を無視しました: 現在のシーンが「${setupSceneName}」ではありません (現在: 「${
+				`「表示開始」を無視しました: 現在のシーンが「${setupSceneName}」ではありません (現在: 「${
 					currentSceneRep.value ?? ""
 				}」)`,
 			);
 			return;
 		}
-		playing = true;
+		playingRep.value = true;
 		consumeNext();
 	});
 
+	// 「表示停止」。ダッシュボード/Stream Deck 共通の入口。
+	nodecg.listenFor("stopTweetQueue", () => {
+		if (!isPlaying()) {
+			return;
+		}
+		logger.info("「表示停止」により、まとめて表示を停止しました");
+		stop();
+	});
+
 	// Setup以外へ切り替わったら即座に停止する。
-	// 再開はユーザーが再度「まとめて表示」を押すまで行わない。
+	// 再開はユーザーが再度「表示開始」を押すまで行わない。
 	currentSceneRep.on("change", (newValue) => {
-		if (playing && newValue !== setupSceneName) {
+		if (isPlaying() && newValue !== setupSceneName) {
 			logger.info(
 				`シーンが「${setupSceneName}」から切り替わったため、まとめて表示を停止しました`,
 			);
 			stop();
 		}
 	});
+
+	// 起動時 (レプリカントが前回値を復元している可能性) は必ず停止状態に戻す。
+	playingRep.value = false;
 };

--- a/src/extension/tweet-queue.ts
+++ b/src/extension/tweet-queue.ts
@@ -1,0 +1,92 @@
+import type {NodeCG} from "./nodecg";
+
+// ファンアート表示のアニメーション (フェードイン1秒 + 表示20秒 + フェードアウト1秒)
+// に画像読み込みなどの余裕を加えた、1件あたりの表示間隔。
+const DISPLAY_INTERVAL_MS = 24 * 1000;
+
+const DEFAULT_SETUP_SCENE_NAME = "Setup";
+
+export const setupTweetQueue = (nodecg: NodeCG) => {
+	const logger = new nodecg.Logger("tweet-queue");
+	const tweetsTempRep = nodecg.Replicant("tweets-temp");
+	const currentSceneRep = nodecg.Replicant("obs-current-scene");
+
+	const setupSceneName =
+		nodecg.bundleConfig.obs?.setupSceneName ?? DEFAULT_SETUP_SCENE_NAME;
+
+	let playing = false;
+	let timer: NodeJS.Timeout | undefined;
+
+	const stop = () => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+		playing = false;
+	};
+
+	// OBSのプログラム側がSetupシーンを表示しているかどうか。
+	const isOnSetupScene = () => currentSceneRep.value === setupSceneName;
+
+	const consumeNext = () => {
+		if (!playing) {
+			return;
+		}
+		// Setup以外のシーンに切り替わっていたら表示処理を停止する。
+		if (!isOnSetupScene()) {
+			stop();
+			return;
+		}
+		const list = tweetsTempRep.value;
+		if (!list) {
+			stop();
+			return;
+		}
+		const index = list.findIndex((tweet) => tweet.queued);
+		const tweet = index === -1 ? undefined : list[index];
+		if (!tweet) {
+			// キューが空になったら終了。
+			stop();
+			return;
+		}
+
+		if (tweet.image) {
+			nodecg.sendMessage("showFanArtTweet", tweet);
+		} else {
+			nodecg.sendMessage("showTweet", tweet);
+		}
+
+		// 表示したツイートはレプリカントの一覧からも削除する。
+		tweetsTempRep.value = [...list.slice(0, index), ...list.slice(index + 1)];
+
+		timer = setTimeout(consumeNext, DISPLAY_INTERVAL_MS);
+	};
+
+	nodecg.listenFor("startTweetQueue", () => {
+		if (playing) {
+			return;
+		}
+		// Setupを表示しているときのみキューの消化を開始する。
+		if (!isOnSetupScene()) {
+			logger.warn(
+				`「まとめて表示」を無視しました: 現在のシーンが「${setupSceneName}」ではありません (現在: 「${
+					currentSceneRep.value ?? ""
+				}」)`,
+			);
+			return;
+		}
+		playing = true;
+		consumeNext();
+	});
+
+	// Setup以外へ切り替わったら即座に停止する。
+	// 再開はユーザーが再度「まとめて表示」を押すまで行わない。
+	currentSceneRep.on("change", (newValue) => {
+		if (playing && newValue !== setupSceneName) {
+			logger.info(
+				`シーンが「${setupSceneName}」から切り替わったため、まとめて表示を停止しました`,
+			);
+			stop();
+		}
+	});
+};

--- a/src/extension/tweet-queue.ts
+++ b/src/extension/tweet-queue.ts
@@ -30,15 +30,22 @@ export const setupTweetQueue = (nodecg: NodeCG) => {
 		playingRep.value = false;
 	};
 
-	// OBSのプログラム側がSetupシーンを表示しているかどうか。
-	const isOnSetupScene = () => currentSceneRep.value === setupSceneName;
+	// シーンが判明していて Setup 以外のときだけブロックする。
+	// OBS WebSocket 切断時などシーンが不明 ("") のときは Setup かどうか判断でき
+	// ないが、ここでブロックすると切断中にファンアートを一切出せなくなる。手動で
+	// 開始/停止できればよく、最悪ゲーム中に消化されてもキューが減るだけで致命的では
+	// ないため、不明なときは制約を緩めて許可する。
+	const isBlockedByScene = () => {
+		const scene = currentSceneRep.value;
+		return Boolean(scene) && scene !== setupSceneName;
+	};
 
 	const consumeNext = () => {
 		if (!isPlaying()) {
 			return;
 		}
-		// Setup以外のシーンに切り替わっていたら表示処理を停止する。
-		if (!isOnSetupScene()) {
+		// Setup以外の (判明している) シーンになっていたら表示処理を停止する。
+		if (isBlockedByScene()) {
 			stop();
 			return;
 		}
@@ -72,8 +79,9 @@ export const setupTweetQueue = (nodecg: NodeCG) => {
 		if (isPlaying()) {
 			return;
 		}
-		// Setupを表示しているときのみキューの消化を開始する。
-		if (!isOnSetupScene()) {
+		// Setup以外の (判明している) シーンのときは開始しない。
+		// シーン不明 (OBS未接続など) のときは制約を緩めて許可する。
+		if (isBlockedByScene()) {
 			logger.warn(
 				`「表示開始」を無視しました: 現在のシーンが「${setupSceneName}」ではありません (現在: 「${
 					currentSceneRep.value ?? ""
@@ -94,10 +102,11 @@ export const setupTweetQueue = (nodecg: NodeCG) => {
 		stop();
 	});
 
-	// Setup以外へ切り替わったら即座に停止する。
+	// Setup以外の (判明している) シーンへ切り替わったら即座に停止する。
+	// 切断などでシーンが不明 ("") になったときは停止しない (制約を緩める)。
 	// 再開はユーザーが再度「表示開始」を押すまで行わない。
 	currentSceneRep.on("change", (newValue) => {
-		if (isPlaying() && newValue !== setupSceneName) {
+		if (isPlaying() && Boolean(newValue) && newValue !== setupSceneName) {
 			logger.info(
 				`シーンが「${setupSceneName}」から切り替わったため、まとめて表示を停止しました`,
 			);

--- a/src/nodecg/messages.d.ts
+++ b/src/nodecg/messages.d.ts
@@ -7,6 +7,7 @@ export type MessageMap = {
 	showFanArtTweet: {
 		data: TweetsTemp[number];
 	};
+	startTweetQueue: {};
 	"twitter:logout": {};
 	"twitter:startLogin": {
 		result: string;

--- a/src/nodecg/messages.d.ts
+++ b/src/nodecg/messages.d.ts
@@ -8,6 +8,7 @@ export type MessageMap = {
 		data: TweetsTemp[number];
 	};
 	startTweetQueue: {};
+	stopTweetQueue: {};
 	"twitter:logout": {};
 	"twitter:startLogin": {
 		result: string;

--- a/src/nodecg/replicants.d.ts
+++ b/src/nodecg/replicants.d.ts
@@ -61,6 +61,7 @@ type ReplicantMap = {
 	tweets: Tweets;
 	"tweets-temp": TweetsTemp;
 	"tweets-temp-images": TweetsTempImages;
+	"tweet-queue-playing": boolean;
 	"obs-status": ObsStatus;
 	"obs-current-scene": ObsCurrentScene;
 	obs: Obs;

--- a/src/nodecg/replicants.d.ts
+++ b/src/nodecg/replicants.d.ts
@@ -12,6 +12,7 @@ import {Obs} from "./generated/obs";
 import {ObsCropInputs} from "./generated/obs-crop-inputs";
 import {ObsRemoteInputs} from "./generated/obs-remote-inputs";
 import {ObsStatus} from "./generated/obs-status";
+import {ObsCurrentScene} from "./generated/obs-current-scene";
 import {Countdown} from "./generated/countdown";
 import {CameraName} from "./generated/camera-name";
 import {CameraState} from "./generated/camera-state";
@@ -61,6 +62,7 @@ type ReplicantMap = {
 	"tweets-temp": TweetsTemp;
 	"tweets-temp-images": TweetsTempImages;
 	"obs-status": ObsStatus;
+	"obs-current-scene": ObsCurrentScene;
 	obs: Obs;
 	"obs-crop-inputs": ObsCropInputs;
 	"obs-remote-inputs": ObsRemoteInputs;
@@ -107,6 +109,7 @@ export type {
 	Commentator,
 	Tweet,
 	Obs,
+	ObsCurrentScene,
 	ObsCropInputs,
 	ObsRemoteInputs,
 	Countdown,

--- a/test/fixtures/sample-data.ts
+++ b/test/fixtures/sample-data.ts
@@ -311,6 +311,7 @@ export const fixtures: Record<string, unknown> = {
 		streamTime: 0,
 		recordTime: 0,
 	},
+	"obs-current-scene": "Setup",
 	tweets: [],
 	"tweets-temp": [],
 	"tweets-temp-images": [],


### PR DESCRIPTION
## 概要

- [#758](https://github.com/RTAinJapan/rtainjapan-layouts/issues/758) の実装。
- ファンアートをキューに溜めておき、セットアップ画面に入ったらワンボタンで順番に発火できるようにする。

## 変更点

### ダッシュボード（Twitterパネル）
- 各ツイートの **✓ ボタン**をファンアートの「即時表示」から「表示キューへの追加/削除トグル」に変更。
  - キューに入っているときにもう一回押すとキューから外れる

<img width="147" height="235" alt="image" src="https://github.com/user-attachments/assets/2872cede-848c-43b5-86de-67a1bdedcacf" />

- 「表示開始」ボタンを追加。押すとキューに溜めたものを順番に発火する。
  - キュー消化中は「表示停止」ボタンとなっており、押すと消化が停止する。
  - 表示中のファンアートはそのまま規定時間まで表示される。（＝停止したからといって、いきなりスッと消えるわけではない）

<img width="859" height="259" alt="image" src="https://github.com/user-attachments/assets/9725812b-f154-492b-911a-b1ea195b0434" />

<img width="395" height="126" alt="image" src="https://github.com/user-attachments/assets/1c3ea1f0-8345-4cb1-bfd5-140cd6d0b5b9" />

### キュー消化（extension `src/extension/tweet-queue.ts` 新規）
- OBS のプログラムシーンが「Setup」のときのみ消化する。
  - **Setup 以外**のシーンに切り替わったら消化を自動で停止
  - 消化停止した状態でまたSetup に戻っても消化再開ということはしない。
    - プレイ中のトラブル等で一時的に Setup に戻った際にファンアートを出さないようにする。

### OBS プログラムシーンの追跡（`src/extension/obs.ts`）
- 既存の OBS 連携は自動録画のみで、シーン追跡をしていなかったためシーンの追跡処理を追加。
  - `EventSubscription.Scenes` を購読し、接続時に `GetCurrentProgramScene`、以降 `CurrentProgramSceneChanged` で現在のプログラムシーン名を取得。
  - 新レプリカント **`obs-current-scene`** に保存（切断時は空）。
  - Setup シーン名は `config.obs.setupSceneName` で定義（既定 `"Setup"`）。
- もともとあった自動録画については `config.obs.autoRecord` をtrueにすると使える。 (既定 `false`)。

## データモデル
- `tweets-temp` の各要素に任意の `queued`（boolean）を追加。
- 新レプリカント `obs-current-scene`（string）。
- `configschema.json` の `obs` に任意の `setupSceneName`（既定 "Setup"）を追加。

## ほか

- ツイート一覧が、登録に応じて一生縦にパネルが伸びていく問題に対応。